### PR TITLE
Fix legend tag

### DIFF
--- a/src/main/resources/templates/companyDetail.html
+++ b/src/main/resources/templates/companyDetail.html
@@ -17,8 +17,7 @@
                 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-two-thirds">
-                            <fieldset class="govuk-fieldset">
-                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">Company Details</legend>
+                            <div class="govuk-fieldset">
                                 <h1 class="govuk-heading-xl" id="company-details-heading" th:utext="#{companyDetails.title}"></h1>
                                 <dl class="app-check-your-answers app-check-your-answers--short">
                                     <div class="app-check-your-answers__contents">
@@ -53,7 +52,7 @@
                                         </dd>
                                     </div>
                                 </dl>
-                            </fieldset>
+                            </div>
                             <div>
                                 <button data-prevent-double-click="true" id="next-button" type="submit" class="govuk-button" name="action" value="submit" th:text="#{button.confirm}"></button>
                             </div>


### PR DESCRIPTION
Legend tag added when fixing sonar issues erroneously appeared on the company details page. This PR fixes that by removing the the legend tag. To fix the sonar issue of having a field-set without a legend; the field-set has been removed and replaced with a div since the field-set wasn't needed as there are no inputs on this page.