### PR TITLE
Change container class to be tablet friendly

### DIFF
--- a/src/main/resources/templates/accessibilityStatement.html
+++ b/src/main/resources/templates/accessibilityStatement.html
@@ -11,12 +11,13 @@
     <div class="govuk-width-container">
         <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
             <div class="govuk-grid-row">
-                <div class="govuk-grid-column-two-thirds">
+                <div class="govuk-grid-column-two-thirds-from-desktop">
                     <h1 class="govuk-heading-xl" th:text="#{accessibilityStatement.heading}">
                     </h1>
                     <p>
                         <span th:text="#{accessibilityStatement.runBy}"></span>
-                        <a th:href="${@environment.getProperty('govuk.ch.url')}" th:text="#{accessibilityStatement.companiesHouse}"></a>
+                        <a th:href="${@environment.getProperty('govuk.ch.url')}"
+                           th:text="#{accessibilityStatement.companiesHouse}"></a>
                         <span th:text="#{accessibilityStatement.asManyAsPossible}"></span>
                     </p>
                     <ul class="govuk-list govuk-list--bullet">

--- a/src/main/resources/templates/categorySelection.html
+++ b/src/main/resources/templates/categorySelection.html
@@ -19,16 +19,17 @@
                th:text="#{link.back}"></a>
             <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
                 <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-two-thirds">
+                    <div class="govuk-grid-column-two-thirds-from-desktop">
                         <div th:replace="fragments/errorSummary :: errorSummary"></div>
                         <fieldset class="govuk-fieldset" data-required="data-required"
                                   th:attr="data-error=#{NotBlankCategoryTemplate.categoryTemplate.details}">
                             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
                                 <span id="category-name" class="govuk-caption-xl"
                                       th:text="*{parentCategory.categoryName}"></span>
-                                <h1 class="govuk-fieldset__heading" th:text="#{categorySelection.catType}"></h1>
+                                <h1 class="govuk-fieldset__heading"
+                                    th:text="#{categorySelection.catType}"></h1>
                             </legend>
-                                <div class="govuk-form-group" th:classappend="${#fields.hasErrors('*')}
+                            <div class="govuk-form-group" th:classappend="${#fields.hasErrors('*')}
                                 ? 'govuk-form-group--error' : ''">
                                     <span id="details-error" class="govuk-error-message"
                                           th:if="${#fields.hasErrors('details')}"

--- a/src/main/resources/templates/companyDetail.html
+++ b/src/main/resources/templates/companyDetail.html
@@ -16,15 +16,17 @@
                    th:text="#{link.back}"></a>
                 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
                     <div class="govuk-grid-row">
-                        <div class="govuk-grid-column-two-thirds">
+                        <div class="govuk-grid-column-two-thirds-from-desktop">
                             <div class="govuk-fieldset">
-                                <h1 class="govuk-heading-xl" id="company-details-heading" th:utext="#{companyDetails.title}"></h1>
+                                <h1 class="govuk-heading-xl" id="company-details-heading"
+                                    th:utext="#{companyDetails.title}"></h1>
                                 <dl class="app-check-your-answers app-check-your-answers--short">
                                     <div class="app-check-your-answers__contents">
                                         <dt th:text="#{companyDetails.companyName}"
                                             class="app-check-your-answers__question">
                                         </dt>
-                                        <dd class="app-check-your-answers__answer"  id="companyDetail-companyName"
+                                        <dd class="app-check-your-answers__answer"
+                                            id="companyDetail-companyName"
                                             th:utext="*{#strings.replace(companyName,'&#10;','&lt;br&gt;')}">
                                         </dd>
                                     </div>

--- a/src/main/resources/templates/confirmation.html
+++ b/src/main/resources/templates/confirmation.html
@@ -12,13 +12,14 @@
 <div class="govuk-width-container">
     <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
         <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-column-two-thirds-from-desktop">
                 <div class="govuk-panel govuk-panel--confirmation-green">
                     <h1 class="govuk-panel__title" th:text="#{confirmation.title}"></h1>
                     <div class="govuk-panel__body">
                         <span th:text="#{confirmation.banner.ref}"></span>
                         <br/>
-                        <span id="confirmation-ref" th:text="${#strings.replace(confirmationRef,' ','&ensp;')}"></span>
+                        <span id="confirmation-ref"
+                              th:text="${#strings.replace(confirmationRef,' ','&ensp;')}"></span>
                     </div>
                 </div>
                 <br/>

--- a/src/main/resources/templates/documentSelection.html
+++ b/src/main/resources/templates/documentSelection.html
@@ -16,16 +16,17 @@
                th:text="#{link.back}"></a>
             <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
                 <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-two-thirds">
+                    <div class="govuk-grid-column-two-thirds-from-desktop">
                         <div th:replace="fragments/errorSummary :: errorSummary"></div>
-                            <fieldset class="govuk-fieldset" data-required="data-required"
-                                      th:attr="data-error=#{NotBlankFormTemplate.formTemplate.details}">
-                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+                        <fieldset class="govuk-fieldset" data-required="data-required"
+                                  th:attr="data-error=#{NotBlankFormTemplate.formTemplate.details}">
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
                                     <span id="category-name" class="govuk-caption-xl"
                                           th:text="${categoryTemplate.categoryName}"></span>
-                                    <h1 class="govuk-fieldset__heading" th:text="#{documentSelection.docType}"></h1>
-                                </legend>
-                                <div class="govuk-form-group" th:classappend="${#fields.hasErrors('*')}
+                                <h1 class="govuk-fieldset__heading"
+                                    th:text="#{documentSelection.docType}"></h1>
+                            </legend>
+                            <div class="govuk-form-group" th:classappend="${#fields.hasErrors('*')}
                                 ? 'govuk-form-group--error' : ''">
                                     <span id="details-error" class="govuk-error-message"
                                           th:if="${#fields.hasErrors('details')}"

--- a/src/main/resources/templates/documentUpload.html
+++ b/src/main/resources/templates/documentUpload.html
@@ -14,16 +14,19 @@
     <!-- Main Content -->
     <main class="govuk-main-wrapper" id="main-content" role="main">
         <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-column-two-thirds-from-desktop">
                 <div th:replace="fragments/errorSummary :: errorSummary"></div>
-                <span class="govuk-caption-xl" th:text="#{documentUpload.companyNameLabel} + ' ' + *{#strings.replace(companyName,'&#10;','&lt;br&gt;')}"></span>
-                <h1 class="govuk-heading-xl govuk-!-margin-bottom-5" th:text="#{documentUpload.title}"></h1>
+                <span class="govuk-caption-xl"
+                      th:text="#{documentUpload.companyNameLabel} + ' ' + *{#strings.replace(companyName,'&#10;','&lt;br&gt;')}"></span>
+                <h1 class="govuk-heading-xl govuk-!-margin-bottom-5"
+                    th:text="#{documentUpload.title}"></h1>
 
                 <!-- Guidance text -->
                 <p class="govuk-body" th:text="#{documentUpload.guidance.heading}"></p>
                 <ul class="govuk-list govuk-list--bullet">
                     <li class="govuk-body" th:text="#{documentUpload.guidance.para1}"></li>
-                    <li class="govuk-body" th:text="#{documentUpload.guidance.para2(*{maximumUploadsAllowed})}"></li>
+                    <li class="govuk-body"
+                        th:text="#{documentUpload.guidance.para2(*{maximumUploadsAllowed})}"></li>
                     <li class="govuk-body" th:text="#{documentUpload.guidance.para3}"></li>
                 </ul>
                 <div th:unless="${showCcReminder}" th:if="*{maximumUploadsAllowed} &gt; 1" class="govuk-inset-text"

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -10,7 +10,7 @@
 <body class="govuk-template__body" layout:fragment="content">
 <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
             <h1 class="govuk-heading-l" th:text="#{500.problemWithService}"></h1>
             <p th:text="#{500.tryAgain}"></p>
             <p th:text="#{500.answersNotSaved}"></p>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -10,13 +10,14 @@
 <body class="govuk-template__body" layout:fragment="content">
 <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
             <h1 class="govuk-heading-l" th:text="#{404.pageNotFound}"></h1>
             <p th:text="#{404.spelledCorrectly}"></p>
             <p th:text="#{404.copiedAddress}"></p>
             <p>
                 <span th:text="#{404.pageMoved}"> </span>
-                <a class="govuk-link" th:href="${@environment.getProperty('start.page.url')}" th:text="#{404.goToStart}"></a>
+                <a class="govuk-link" th:href="${@environment.getProperty('start.page.url')}"
+                   th:text="#{404.goToStart}"></a>
             </p>
         </div>
     </div>

--- a/src/main/resources/templates/error/410.html
+++ b/src/main/resources/templates/error/410.html
@@ -10,7 +10,7 @@
 <body class="govuk-template__body" layout:fragment="content">
 <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
             <h1 class="govuk-heading-l" th:text="#{410.title}"></h1>
             <p>
                 <span th:text="#{410.link.text1}"> </span>

--- a/src/main/resources/templates/guidance.html
+++ b/src/main/resources/templates/guidance.html
@@ -12,7 +12,7 @@
     <a th:href="${@environment.getProperty('start.page.url')}" class="govuk-back-link" th:text="#{link.back}"></a>
     <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
         <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-column-two-thirds-from-desktop">
                 <span class="govuk-caption-xl" th:text="#{guidance.text}"></span>
                 <h1 class="govuk-heading-xl" th:text="#{guidance.page.title}"></h1>
                 <p class="govuk-body-l" th:text="#{guidance.how.to}"></p>
@@ -20,7 +20,8 @@
                     <span th:text="#{guidance.inset.text}"></span>
                 </div>
                 <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible govuk-!-margin-bottom-3">
-                <p class="govuk-body-s govuk-!-margin-bottom-1" th:text="#{guidance.published.date}"></p>
+                <p class="govuk-body-s govuk-!-margin-bottom-1"
+                   th:text="#{guidance.published.date}"></p>
                 <p class="govuk-body-s">
                     <span th:text="#{guidance.from}"></span>
                     <a class="govuk-link govuk-!-font-weight-bold" th:href="${@environment.getProperty('govuk.ch.url')}">

--- a/src/main/resources/templates/paymentRequired.html
+++ b/src/main/resources/templates/paymentRequired.html
@@ -20,15 +20,17 @@
 
         <!-- Main Wrapper -->
         <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-column-two-thirds-from-desktop">
                 <div th:replace="fragments/errorSummary :: errorSummary"></div>
                 <!-- Page Content -->
-                <div id="content-wrapper" class="govuk-form-group" th:classappend="${#fields.hasErrors('paymentReference')} ? govuk-form-group--error : noerror">
+                <div id="content-wrapper" class="govuk-form-group"
+                     th:classappend="${#fields.hasErrors('paymentReference')} ? govuk-form-group--error : noerror">
 
                     <fieldset class="govuk-fieldset" aria-describedby="page-heading">
 
                         <!-- Display Title -->
-                        <h1 id="page-heading" class="govuk-heading-xl" th:text="#{paymentRequired.heading}"></h1>
+                        <h1 id="page-heading" class="govuk-heading-xl"
+                            th:text="#{paymentRequired.heading}"></h1>
 
                         <p class="govuk-body" th:text="#{paymentRequired.guidance.para1}"></p>
                         <div class="govuk-inset-text" th:text="#{paymentRequired.guidance.hint}"></div>

--- a/src/main/resources/templates/removeDocument.html
+++ b/src/main/resources/templates/removeDocument.html
@@ -19,17 +19,20 @@
 
         <!-- Main Wrapper -->
         <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-column-two-thirds-from-desktop">
                 <div th:replace="fragments/errorSummary :: errorSummary"></div>
 
                 <!-- Page Content -->
-                <div id="content-wrapper" class="govuk-form-group" th:classappend="${#fields.hasErrors('required')} ? govuk-form-group--error : noerror">
+                <div id="content-wrapper" class="govuk-form-group"
+                     th:classappend="${#fields.hasErrors('required')} ? govuk-form-group--error : noerror">
 
                     <fieldset class="govuk-fieldset" aria-describedby="page-heading">
 
                         <!-- Display Question -->
                         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                            <h1 id="page-heading" class="govuk-fieldset__heading" style="word-break: break-word" th:text="#{removeDocument.page.title(${removeDocument.getFileName()})}"></h1>
+                            <h1 id="page-heading" class="govuk-fieldset__heading"
+                                style="word-break: break-word"
+                                th:text="#{removeDocument.page.title(${removeDocument.getFileName()})}"></h1>
                         </legend>
 
                         <!-- Error Message -->

--- a/src/main/resources/templates/resolutionsInfo.html
+++ b/src/main/resources/templates/resolutionsInfo.html
@@ -16,7 +16,7 @@
                (id=*{submissionId}, companyNumber=*{companyNumber},category=*{details.formCategory})}" th:text="#{link.back}"></a>
             <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
                 <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-two-thirds">
+                    <div class="govuk-grid-column-two-thirds-from-desktop">
                         <h1 class="govuk-heading-xl" th:text="#{resolutionsInfo.header}"></h1>
                         <h2 class="govuk-heading-m" th:text="#{resolutionsInfo.cannot}"></h2>
                         <ul class="govuk-list govuk-list--bullet">
@@ -25,7 +25,8 @@
                         </ul>
                         <div>
                             <button data-prevent-double-click="true" id="submit-all" type="submit"
-                                    class="govuk-button" name="action" value="submit" th:text="#{button.continue}"></button>
+                                    class="govuk-button" name="action" value="submit"
+                                    th:text="#{button.continue}"></button>
                         </div>
                     </div>
                 </div>

--- a/src/main/resources/templates/start.html
+++ b/src/main/resources/templates/start.html
@@ -11,7 +11,7 @@
     <div class="govuk-width-container">
         <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
             <div class="govuk-grid-row">
-                <div class="govuk-grid-column-two-thirds">
+                <div class="govuk-grid-column-two-thirds-from-desktop">
                     <h1 class="govuk-heading-xl" th:text="#{start.title}"></h1>
                     <p class="govuk-body-lead" th:text="#{start.service.description}"></p>
                     <p class="govuk-body" th:text="#{start.upload.certain.documents}"></p>


### PR DESCRIPTION
Change container class from `govuk-grid-column-two-thirds` to `govuk-grid-column-two-thirds-from-desktop`. This allows the view to go to 100% width at 1020px or lower as apposed to 640px.

Resolves: [BI-5796](https://companieshouse.atlassian.net/browse/BI-5796)