### PR TITLE
Centered warning exclamation mark

### DIFF
--- a/src/main/resources/templates/confirmation.html
+++ b/src/main/resources/templates/confirmation.html
@@ -33,7 +33,7 @@
                 </div>
                 <div class="govuk-warning-text">
                     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                    <strong class="govuk-warning-text__text govuk-!-margin-left-2">
+                    <strong class="govuk-warning-text__text govuk-!-margin-left-2 govuk-!-margin-top-4">
                         <span class="govuk-warning-text__assistive">Warning</span>
                         <span th:text="#{confirmation.happens.warning.text}"></span>
                     </strong>

--- a/src/main/resources/templates/confirmation.html
+++ b/src/main/resources/templates/confirmation.html
@@ -33,7 +33,7 @@
                 </div>
                 <div class="govuk-warning-text">
                     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                    <strong class="govuk-warning-text__text" style="padding-left: 65px;">
+                    <strong class="govuk-warning-text__text govuk-!-margin-left-2">
                         <span class="govuk-warning-text__assistive">Warning</span>
                         <span th:text="#{confirmation.happens.warning.text}"></span>
                     </strong>


### PR DESCRIPTION
Change in styles to centre the exclamation mark in the cvid warning on the confirmation page