### PR TITLE
Clearing form details from model when different category selected

### DIFF
--- a/src/main/java/uk/gov/companieshouse/efs/web/formtemplates/controller/FormTemplateControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/formtemplates/controller/FormTemplateControllerImpl.java
@@ -7,9 +7,11 @@ import static uk.gov.companieshouse.efs.web.formtemplates.controller.FormTemplat
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 import javax.servlet.ServletRequest;
 import javax.validation.Valid;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -108,6 +110,19 @@ public class FormTemplateControllerImpl extends BaseControllerImpl implements Fo
 
         formTemplateAttribute.setFormTemplateList(formList);
         formTemplateAttribute.setSubmissionId(submissionApi.getId());
+
+        final Optional<FormTemplateApi> selectedForm = formTemplateAttribute.getFormTemplateList().stream()
+            .filter(f -> f.getFormType().equals(formTemplateAttribute.getFormType()))
+            .findFirst();
+        // selected form category must match the category otherwise the user hasn't selected
+        // a form for the last selected category
+        final boolean formNotSelected = !selectedForm.isPresent()
+                                        || !StringUtils.equals(selectedForm.get().getFormCategory(),
+            categoryTemplateAttribute.getCategoryType());
+        if (formNotSelected) {
+            formTemplateAttribute.setDetails(new FormTemplateApi());
+        }
+
         model.addAttribute("categoryName", categoryTemplateAttribute.getCategoryName());
         model.addAttribute("isScottishCompany", isScottishCompany(companyNumber));
         addTrackingAttributeToModel(model);

--- a/src/test/java/uk/gov/companieshouse/efs/web/formtemplates/controller/FormTemplateControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/formtemplates/controller/FormTemplateControllerTest.java
@@ -11,10 +11,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/uk/gov/companieshouse/efs/web/formtemplates/controller/FormTemplateControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/formtemplates/controller/FormTemplateControllerTest.java
@@ -3,14 +3,18 @@ package uk.gov.companieshouse.efs.web.formtemplates.controller;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -59,7 +63,8 @@ class FormTemplateControllerTest extends BaseControllerImplTest {
             "100", true, true);
     public static final FormTemplateApi FORM_TEMPLATE_2 = new FormTemplateApi("CC02", "Test02", "CAT1_SUB_LEVEL1",
             "100", true, true);
-    public static final FormTemplateApi FORM_TEMPLATE_3 = new FormTemplateApi("CC03", "Test03", "CAT1_SUB_LEVEL1",
+    public static final FormTemplateApi FORM_TEMPLATE_3 = new FormTemplateApi("CC03", "Test03", "CAT1_SUB_LEVEL1",                          "100", true, true);
+    public static final FormTemplateApi INS_TEMPLATE_1 = new FormTemplateApi("INS", "InsTest04", "INS_SUB_LEVEL1",
             "100", true, true);
     public static final List<FormTemplateApi> FORM_TEMPLATE_LIST = Arrays.asList(FORM_TEMPLATE_1, FORM_TEMPLATE_2, FORM_TEMPLATE_3);
 
@@ -117,16 +122,7 @@ class FormTemplateControllerTest extends BaseControllerImplTest {
         presenter.setEmail(PRESENTER_EMAIL);
         submission.setPresenter(presenter);
 
-        when(apiClientService.getSubmission(SUBMISSION_ID)).thenReturn(
-                getSubmissionOkResponse(submission));
-
-        when(apiClientService.isOnAllowList(PRESENTER_EMAIL)).
-                thenReturn(new ApiResponse(200, getHeaders(), true));
-
-        when(formTemplateService.getFormTemplatesByCategory(CAT1_SUB_LEVEL1.getCategoryType())).
-                thenReturn(new ApiResponse(200, getHeaders(), new FormTemplateListApi(FORM_TEMPLATE_LIST)));
-
-        when(categoryTemplateAttribute.getCategoryName()).thenReturn(CAT1_SUB_LEVEL1.getCategoryName());
+        expectOpenSubmission(submission, CAT1_SUB_LEVEL1);
 
         String template = testController.formTemplate(SUBMISSION_ID, COMPANY_NUMBER, CAT1_SUB_LEVEL1.getCategoryType(),
                 categoryTemplateAttribute, formTemplateAttribute, model, servletRequest);
@@ -135,6 +131,60 @@ class FormTemplateControllerTest extends BaseControllerImplTest {
         verify(formTemplateAttribute).setSubmissionId(SUBMISSION_ID);
         verify(model).addAttribute("categoryName", categoryTemplateAttribute.getCategoryName());
         verify(model).addAttribute(TEMPLATE_NAME, ViewConstants.DOCUMENT_SELECTION.asView());
+
+        assertThat(template, is(ViewConstants.DOCUMENT_SELECTION.asView()));
+
+    }
+
+    @Test
+    void formTemplateWhenSubmissionOpenAndFormSelectedSameCategory() {
+
+        final SubmissionApi submission = createSubmission(SubmissionStatus.OPEN);
+        PresenterApi presenter = new PresenterApi();
+        presenter.setEmail(PRESENTER_EMAIL);
+        submission.setPresenter(presenter);
+
+        expectOpenSubmission(submission, CAT1_SUB_LEVEL1);
+
+        when(categoryTemplateAttribute.getCategoryType()).thenReturn(CAT1_SUB_LEVEL1.getCategoryType());
+
+        when(formTemplateAttribute.getFormTemplateList()).thenReturn(FORM_TEMPLATE_LIST);
+
+        when(formTemplateAttribute.getFormType()).thenReturn(FORM_TEMPLATE_1.getFormType());
+
+        String template = testController.formTemplate(SUBMISSION_ID, COMPANY_NUMBER, CAT1_SUB_LEVEL1.getCategoryType(),
+            categoryTemplateAttribute, formTemplateAttribute, model, servletRequest);
+
+        verify(formTemplateAttribute, never()).setDetails(any(FormTemplateApi.class));
+        verify(formTemplateAttribute).setFormTemplateList(FORM_TEMPLATE_LIST);
+        verify(formTemplateAttribute).setSubmissionId(SUBMISSION_ID);
+        verify(model).addAttribute("categoryName", categoryTemplateAttribute.getCategoryName());
+        verify(model).addAttribute(TEMPLATE_NAME, ViewConstants.DOCUMENT_SELECTION.asView());
+
+        assertThat(template, is(ViewConstants.DOCUMENT_SELECTION.asView()));
+
+    }
+
+    @Test
+    void formTemplateWhenSubmissionOpenAndFormSelectedDifferentCategory() {
+
+        final SubmissionApi submission = createSubmission(SubmissionStatus.OPEN);
+        PresenterApi presenter = new PresenterApi();
+        presenter.setEmail(PRESENTER_EMAIL);
+        submission.setPresenter(presenter);
+
+        expectOpenSubmission(submission, CAT2_SUB_LEVEL1);
+
+        when(categoryTemplateAttribute.getCategoryType()).thenReturn(CAT2_SUB_LEVEL1.getCategoryType());
+
+        when(formTemplateAttribute.getFormTemplateList()).thenReturn(FORM_TEMPLATE_LIST);
+
+        when(formTemplateAttribute.getFormType()).thenReturn(FORM_TEMPLATE_1.getFormType());
+
+        String template = testController.formTemplate(SUBMISSION_ID, COMPANY_NUMBER, CAT2_SUB_LEVEL1.getCategoryType(),
+            categoryTemplateAttribute, formTemplateAttribute, model, servletRequest);
+
+        verify(formTemplateAttribute).setDetails(any(FormTemplateApi.class));
 
         assertThat(template, is(ViewConstants.DOCUMENT_SELECTION.asView()));
 
@@ -202,16 +252,7 @@ class FormTemplateControllerTest extends BaseControllerImplTest {
         presenter.setEmail(PRESENTER_EMAIL);
         submission.setPresenter(presenter);
 
-        when(apiClientService.getSubmission(SUBMISSION_ID)).thenReturn(
-                getSubmissionOkResponse(submission));
-
-        when(apiClientService.isOnAllowList(PRESENTER_EMAIL)).
-                thenReturn(new ApiResponse(200, getHeaders(), true));
-
-        when(formTemplateService.getFormTemplatesByCategory(CAT1_SUB_LEVEL1.getCategoryType())).
-                thenReturn(new ApiResponse(200, getHeaders(), new FormTemplateListApi(FORM_TEMPLATE_LIST)));
-
-        when(categoryTemplateAttribute.getCategoryName()).thenReturn(CAT1_SUB_LEVEL1.getCategoryName());
+        expectOpenSubmission(submission, CAT1_SUB_LEVEL1);
 
         String template = testController.formTemplate(SUBMISSION_ID, companyNumber, CAT1_SUB_LEVEL1.getCategoryType(),
                 categoryTemplateAttribute, formTemplateAttribute, model, servletRequest);
@@ -219,5 +260,21 @@ class FormTemplateControllerTest extends BaseControllerImplTest {
         verify(model).addAttribute("isScottishCompany", Boolean.TRUE);
 
         assertThat(template, is(ViewConstants.DOCUMENT_SELECTION.asView()));
+    }
+
+    private void expectOpenSubmission(final SubmissionApi submission,
+        final CategoryTemplateApi categoryTemplate) {
+        when(apiClientService.getSubmission(SUBMISSION_ID))
+            .thenReturn(getSubmissionOkResponse(submission));
+
+        when(apiClientService.isOnAllowList(PRESENTER_EMAIL)).
+            thenReturn(new ApiResponse(200, getHeaders(), true));
+
+        when(formTemplateService.getFormTemplatesByCategory(categoryTemplate.getCategoryType())).
+            thenReturn(
+                new ApiResponse(200, getHeaders(), new FormTemplateListApi(FORM_TEMPLATE_LIST)));
+
+        when(categoryTemplateAttribute.getCategoryName())
+            .thenReturn(categoryTemplate.getCategoryName());
     }
 }


### PR DESCRIPTION
User was getting an error because validation wasn't being done.  
Now if the user changes the category the form is cleared from the model.

This covers both defects, including when a new submission is done for the same company.
- BI-6363
- BI-6390