### PR TITLE
Make a kilobyte 1024

### DIFF
--- a/src/main/java/uk/gov/companieshouse/efs/web/model/DocumentUploadModel.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/model/DocumentUploadModel.java
@@ -190,7 +190,7 @@ public class DocumentUploadModel {
      * @return The human-readable string representation of the files size.
      */
     public static String displayFileSizeAsHuman(final FileApi file) {
-        final int UNIT = 1000;
+        final int UNIT = 1024;
         if (file.getFileSize() < UNIT) {
             return file.getFileSize() + " B";
         }

--- a/src/main/java/uk/gov/companieshouse/efs/web/validation/DocumentUploadValidator.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/validation/DocumentUploadValidator.java
@@ -103,7 +103,7 @@ public class DocumentUploadValidator implements BiFunction<DocumentUploadModel, 
     }
 
     private long toByteCount(final String sizeHuman) {
-        final int KILOBYTE = 1000;
+        final int KILOBYTE = 1024;
 
         long returnValue = Long.MAX_VALUE;
 

--- a/src/test/java/uk/gov/companieshouse/efs/web/validation/DocumentUploadValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/validation/DocumentUploadValidatorTest.java
@@ -38,12 +38,13 @@ import uk.gov.companieshouse.efs.web.configuration.FileUploadConfiguration;
 import uk.gov.companieshouse.efs.web.model.DocumentUploadModel;
 
 @ExtendWith(MockitoExtension.class)
-public class DocumentUploadValidatorTest {
+class DocumentUploadValidatorTest {
 
     private static final Integer MINIMUM_UPLOADS_ALLOWED    = 1;
     private static final Integer MAXIMUM_UPLOADS_ALLOWED    = 10;
 
     private static final String PDF_VALUE = "PDF";
+    private static final int KILOBYTE = 1024;
 
     @Mock
     private FileUploadConfiguration fileUploadConfiguration;
@@ -236,7 +237,7 @@ public class DocumentUploadValidatorTest {
         when(resourceBundle.getString("max_file_size_exceeded.documentUpload"))
                 .thenReturn("The selected file must be smaller than {0}");
 
-        String fileContent = createContent(4*1024*1024 + 1);
+        String fileContent = createContent(4 * KILOBYTE * KILOBYTE + 1);
 
         DocumentUploadModel model = new DocumentUploadModel(fileUploadConfiguration);
         model.setDetails(createFiles(MINIMUM_UPLOADS_ALLOWED));

--- a/src/test/java/uk/gov/companieshouse/efs/web/validation/DocumentUploadValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/validation/DocumentUploadValidatorTest.java
@@ -236,7 +236,7 @@ public class DocumentUploadValidatorTest {
         when(resourceBundle.getString("max_file_size_exceeded.documentUpload"))
                 .thenReturn("The selected file must be smaller than {0}");
 
-        String fileContent = createContent(4000001);
+        String fileContent = createContent(4*1024*1024 + 1);
 
         DocumentUploadModel model = new DocumentUploadModel(fileUploadConfiguration);
         model.setDetails(createFiles(MINIMUM_UPLOADS_ALLOWED));


### PR DESCRIPTION
- this is the file size used in [file-transfer-api](https://github.com/companieshouse/file-transfer-api/blob/master/src/routes/file-upload.ts#L11)
- BI-6457

this now allowed me to upload the pdf attached in defect:
<img width="497" alt="Screenshot 2021-01-07 at 11 02 53" src="https://user-images.githubusercontent.com/2736331/103885434-ec71be00-50d7-11eb-9ff0-92219c188cc7.png">

Note to dev in vagrant - please refer to comment in story to increase file size allowed in nginx 