### PR TITLE
Guidance and Insolvency Guidance - continuation page

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -204,6 +204,8 @@ guidance.continuation.pages.text=If you need to include continuation pages with 
 guidance.how.to.upload.documents=How to upload documents usually filed together
 guidance.how.to.upload.documents.para1=For now, you can only upload one document at a time in this service.
 guidance.how.to.upload.documents.para2=If you need to upload a package of documents that you would usually file together, you must upload each document separately. This means you must start the service again for each document you need to upload. You can either restart the service or use the link on the confirmation page after you've uploaded a document.
+guidance.how.to.upload.documents.para3=You should do this as soon as possible after you've uploaded the previous document so that associated documents can be processed together.
+guidance.how.to.upload.documents.para4=Otherwise, some documents may be rejected for missing the required supporting documents.
 # Insolvency Guidance page
 insolvency.guidance.title=Guidance - Upload a document to Companies House: insolvency
 insolvency.guidance.page.title=Upload a document to Companies House: insolvency

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -199,7 +199,11 @@ guidance.signature.item3=scanned onto the form
 guidance.signature.item4=hand-written in black ink
 guidance.cover.letter=Cover letters
 guidance.cover.letter.text=For now, you cannot upload cover letters in this service. You must upload the document only.
-
+guidance.continuation.pages=Continuation pages
+guidance.continuation.pages.text=If you need to include continuation pages with your submission, you must merge the document and the continuation pages first. This enables you to upload the document and continuation pages as one document.
+guidance.how.to.upload.documents=How to upload documents usually filed together
+guidance.how.to.upload.documents.para1=For now, you can only upload one document at a time in this service.
+guidance.how.to.upload.documents.para2=If you need to upload a package of documents that you would usually file together, you must upload each document separately. This means you must start the service again for each document you need to upload. You can either restart the service or use the link on the confirmation page after you've uploaded a document.
 # Insolvency Guidance page
 insolvency.guidance.title=Guidance - Upload a document to Companies House: insolvency
 insolvency.guidance.page.title=Upload a document to Companies House: insolvency

--- a/src/main/resources/templates/fragments/guidance/continuationPages.html
+++ b/src/main/resources/templates/fragments/guidance/continuationPages.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html
+        xmlns:th="http://www.thymeleaf.org"
+        lang="en">
+<head>
+    <title></title>
+</head>
+<body>
+    <div th:fragment="continuationPages">
+        <h3 class="govuk-heading-m" id="" th:text="#{guidance.continuation.pages}"></h3>
+        <p class="govuk-body" th:text="#{guidance.continuation.pages.text}"></p>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/guidance/howToUploadDocuments.html
+++ b/src/main/resources/templates/fragments/guidance/howToUploadDocuments.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html
+        xmlns:th="http://www.thymeleaf.org"
+        lang="en">
+<head>
+    <title></title>
+</head>
+<body>
+    <div th:fragment="howToUploadDocuments">
+        <h2 class="govuk-heading-l" id="" th:text="#{guidance.how.to.upload.documents}"></h2>
+        <p class="govuk-body" th:text="#{guidance.how.to.upload.documents.para1}"></p>
+        <p class="govuk-body" th:text="#{guidance.how.to.upload.documents.para2}"></p>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/guidance/howToUploadDocuments.html
+++ b/src/main/resources/templates/fragments/guidance/howToUploadDocuments.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     <div th:fragment="howToUploadDocuments">
-        <h2 class="govuk-heading-l" id="" th:text="#{guidance.how.to.upload.documents}"></h2>
+        <h2 class="govuk-heading-l" id="how-to-upload-documents" th:text="#{guidance.how.to.upload.documents}"></h2>
         <p class="govuk-body" th:text="#{guidance.how.to.upload.documents.para1}"></p>
         <p class="govuk-body" th:text="#{guidance.how.to.upload.documents.para2}"></p>
     </div>

--- a/src/main/resources/templates/fragments/guidance/howToUploadDocuments.html
+++ b/src/main/resources/templates/fragments/guidance/howToUploadDocuments.html
@@ -6,10 +6,14 @@
     <title></title>
 </head>
 <body>
-    <div th:fragment="howToUploadDocuments">
+    <div th:fragment="howToUploadDocuments (include_para4)">
         <h2 class="govuk-heading-l" id="how-to-upload-documents" th:text="#{guidance.how.to.upload.documents}"></h2>
         <p class="govuk-body" th:text="#{guidance.how.to.upload.documents.para1}"></p>
         <p class="govuk-body" th:text="#{guidance.how.to.upload.documents.para2}"></p>
+        <p class="govuk-body">
+            <span th:text="#{guidance.how.to.upload.documents.para3}"></span>
+            <span th:if="${include_para4}" th:text="#{guidance.how.to.upload.documents.para4}"></span>
+        </p>
     </div>
 </body>
 </html>

--- a/src/main/resources/templates/guidance.html
+++ b/src/main/resources/templates/guidance.html
@@ -41,6 +41,11 @@
                         </a>
                     </li>
                     <li>
+                        <a class="govuk-link govuk-body-s" href="#how-to-upload-documents">
+                            <span th:text="#{guidance.how.to.upload.documents}"></span>
+                        </a>
+                    </li>
+                    <li>
                         <a class="govuk-link govuk-body-s" href="#documents-that-need-evidence">
                             <span th:text="#{guidance.documents.that.need.evidence}"></span>
                         </a>
@@ -412,6 +417,10 @@
                 <p class="govuk-body" th:text="#{guidance.cover.letter.text}"></p>
                 <div th:replace="fragments/guidance/continuationPages :: continuationPages"></div>
                 <div th:replace="fragments/guidance/howToUploadDocuments :: howToUploadDocuments"></div>
+                <p class="govuk-body">
+                    <span th:text="#{guidance.how.to.upload.documents.para3}"></span>
+                    <span th:text="#{guidance.how.to.upload.documents.para4}"></span>
+                </p>
                 <h2 class="govuk-heading-l" id="documents-that-need-evidence" th:text="#{guidance.documents.that.need.evidence}"></h2>
                 <h3 class="govuk-heading-m" th:text="#{guidance.documents.that.need.evidence.form.name}"></h3>
                 <p class="govuk-body" th:text="#{guidance.documents.that.need.evidence.guide}"></p>

--- a/src/main/resources/templates/guidance.html
+++ b/src/main/resources/templates/guidance.html
@@ -416,11 +416,8 @@
                 <h3 class="govuk-heading-m" th:text="#{guidance.cover.letter}"></h3>
                 <p class="govuk-body" th:text="#{guidance.cover.letter.text}"></p>
                 <div th:replace="fragments/guidance/continuationPages :: continuationPages"></div>
-                <div th:replace="fragments/guidance/howToUploadDocuments :: howToUploadDocuments"></div>
-                <p class="govuk-body">
-                    <span th:text="#{guidance.how.to.upload.documents.para3}"></span>
-                    <span th:text="#{guidance.how.to.upload.documents.para4}"></span>
-                </p>
+                <div th:replace="fragments/guidance/howToUploadDocuments :: howToUploadDocuments(include_para4='true')"></div>
+
                 <h2 class="govuk-heading-l" id="documents-that-need-evidence" th:text="#{guidance.documents.that.need.evidence}"></h2>
                 <h3 class="govuk-heading-m" th:text="#{guidance.documents.that.need.evidence.form.name}"></h3>
                 <p class="govuk-body" th:text="#{guidance.documents.that.need.evidence.guide}"></p>

--- a/src/main/resources/templates/guidance.html
+++ b/src/main/resources/templates/guidance.html
@@ -410,6 +410,8 @@
                 </ul>
                 <h3 class="govuk-heading-m" th:text="#{guidance.cover.letter}"></h3>
                 <p class="govuk-body" th:text="#{guidance.cover.letter.text}"></p>
+                <div th:replace="fragments/guidance/continuationPages :: continuationPages"></div>
+                <div th:replace="fragments/guidance/howToUploadDocuments :: howToUploadDocuments"></div>
                 <h2 class="govuk-heading-l" id="documents-that-need-evidence" th:text="#{guidance.documents.that.need.evidence}"></h2>
                 <h3 class="govuk-heading-m" th:text="#{guidance.documents.that.need.evidence.form.name}"></h3>
                 <p class="govuk-body" th:text="#{guidance.documents.that.need.evidence.guide}"></p>

--- a/src/main/resources/templates/insolvencyGuidance.html
+++ b/src/main/resources/templates/insolvencyGuidance.html
@@ -147,10 +147,7 @@
 
                 <div th:replace="fragments/guidance/continuationPages :: continuationPages"></div>
 
-                <div th:replace="fragments/guidance/howToUploadDocuments :: howToUploadDocuments"></div>
-                <p class="govuk-body">
-                    <span th:text="#{guidance.how.to.upload.documents.para3}"></span>
-                </p>
+                <div th:replace="fragments/guidance/howToUploadDocuments :: howToUploadDocuments(include_para4='false')"></div>
 
                 <h2 class="govuk-heading-l" id="what-happens-next" th:text="#{guidance.what.happens.next}"></h2>
                 <p class="govuk-body" th:text="#{insolvency.guidance.what.happens.next.text1}"></p>

--- a/src/main/resources/templates/insolvencyGuidance.html
+++ b/src/main/resources/templates/insolvencyGuidance.html
@@ -140,6 +140,10 @@
                 <h3 class="govuk-heading-m" th:text="#{insolvency.guidance.cover.letter}"></h3>
                 <p class="govuk-body" th:text="#{insolvency.guidance.cover.letter.text}"></p>
 
+                <div th:replace="fragments/guidance/continuationPages :: continuationPages"></div>
+
+                <div th:replace="fragments/guidance/howToUploadDocuments :: howToUploadDocuments"></div>
+
                 <h2 class="govuk-heading-l" id="what-happens-next" th:text="#{guidance.what.happens.next}"></h2>
                 <p class="govuk-body" th:text="#{insolvency.guidance.what.happens.next.text1}"></p>
                 <p class="govuk-body" th:text="#{insolvency.guidance.what.happens.next.text2}"></p>

--- a/src/main/resources/templates/insolvencyGuidance.html
+++ b/src/main/resources/templates/insolvencyGuidance.html
@@ -46,6 +46,11 @@
                         </a>
                     </li>
                     <li>
+                        <a class="govuk-link govuk-body-s" href="#how-to-upload-documents">
+                            <span th:text="#{guidance.how.to.upload.documents}"></span>
+                        </a>
+                    </li>
+                    <li>
                         <a class="govuk-link govuk-body-s" href="#what-happens-next">
                             <span th:text="#{guidance.what.happens.next}"></span>
                         </a>
@@ -143,6 +148,9 @@
                 <div th:replace="fragments/guidance/continuationPages :: continuationPages"></div>
 
                 <div th:replace="fragments/guidance/howToUploadDocuments :: howToUploadDocuments"></div>
+                <p class="govuk-body">
+                    <span th:text="#{guidance.how.to.upload.documents.para3}"></span>
+                </p>
 
                 <h2 class="govuk-heading-l" id="what-happens-next" th:text="#{guidance.what.happens.next}"></h2>
                 <p class="govuk-body" th:text="#{insolvency.guidance.what.happens.next.text1}"></p>


### PR DESCRIPTION
Adds paragraph for Continuation pages and a new section 'How to upload documents usually filed together'

Using fragments to avoid duplication - this approach should probably be done for large parts of the rest of the guidance pages.

BI-6583
BI-6598