### PR TITLE
Dynamic text on Document Upload for Share Capital forms

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -292,8 +292,9 @@ documentUpload.guidance3.para2=use a {0} format
 documentUpload.guidance3.para3=upload supporting evidence
 documentUpload.guidance3.para4=You can upload up to {0} files including the completed {1} and the evidence. The files you upload must be less than {2} in total.
 
-
-
+documentUpload.guidance4.para1=You can only upload one document at a time.
+documentUpload.guidance4.para2=If you need to upload more documents, you must start the service again to upload each one separately. You can either restart the service or use the link on the confirmation page after you've uploaded this document.
+documentUpload.guidance4.para3=For now, you cannot upload form SH03 in this service. Do not attach form SH03 to this document.
 
 documentUpload.guidance.help=If you are uploading a document that requires supporting evidence, you can upload up to 10 files including the completed document and the evidence.
 documentUpload.guidance.help.fes=If you need to upload multiple documents, such as evidence, you must upload it as one PDF document (including the form).

--- a/src/main/resources/templates/fragments/documentUpload/guidance.html
+++ b/src/main/resources/templates/fragments/documentUpload/guidance.html
@@ -47,5 +47,11 @@
     <div class="govuk-inset-text" th:text="#{documentUpload.guidance3.para4(*{maximumUploadsAllowed},${formType},*{maximumFileSize})}"></div>
 </div>
 
+<div th:fragment="guidance4">
+    <p class="govuk-body" th:text="#{documentUpload.guidance4.para1}"></p>
+    <div class="govuk-inset-text" th:text="#{documentUpload.guidance4.para2}"></div>
+    <p class="govuk-body" th:if="${#strings.equals(formType,'SH06')}" th:text="#{documentUpload.guidance4.para3}"></p>
+</div>
+
 </body>
 </html>


### PR DESCRIPTION
Add a fragment for the share capital form text with a condition for displaying extra text in SH06 form

BI-6639
Corresponding API - https://github.com/companieshouse/efs-submission-api/pull/21

This is what the SH06 looks like with the extra sentence:

<img width="533" alt="Screenshot 2021-01-28 at 10 41 37" src="https://user-images.githubusercontent.com/2736331/106126594-74863900-6155-11eb-9ea7-e6d0b372a422.png">
