### PR TITLE
Amend the text read for Change Document upload

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -332,6 +332,7 @@ checkDetails.company.number=Company number
 checkDetails.document.heading=Document details
 checkDetails.document.type=Document type
 checkDetails.document.uploaded=Document{0,choice,1#|1<s} uploaded
+checkDetails.document.uploaded.screen.reader=Document uploaded
 checkDetails.payment.charge=Amount to pay
 checkDetails.authorised.heading=Confirm authorisation
 checkDetails.authorised.statement=I confirm I am authorised to send this document for filing.

--- a/src/main/resources/templates/checkDetails.html
+++ b/src/main/resources/templates/checkDetails.html
@@ -58,7 +58,7 @@
                             <dd class="govuk-summary-list__actions">
                                 <a class="govuk-link"
                                    th:href="@{/efs-submission/{id}/company/{companyNumber}/document-upload(id=*{submissionId},companyNumber=*{companyNumber})}">
-                                    [[#{checkDetails.action.change}]]<span class="govuk-visually-hidden"> [[#{checkDetails.document.uploaded}]]</span>
+                                    [[#{checkDetails.action.change}]]<span class="govuk-visually-hidden"> [[#{checkDetails.document.uploaded.screen.reader}]]</span>
                                 </a>
                             </dd>
                         </div>


### PR DESCRIPTION
The text displayed for the label is unchanged - singular and plural 'Document' still works
But have amended what is read to always just say "Change Document uploaded".
- this was considered acceptable for the majority of forms, better than what we've got for the release and later we can run it past the UX team. 

BI-6762

<img width="523" alt="Screenshot 2021-02-01 at 10 04 30" src="https://user-images.githubusercontent.com/2736331/106443832-e4a5ff00-6474-11eb-8796-c49762cf11cb.png">