### PR TITLE
add messageTextList attribute upon errors in validation

### DIFF
--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/DocumentUploadControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/DocumentUploadControllerImpl.java
@@ -114,11 +114,7 @@ public class DocumentUploadControllerImpl extends BaseControllerImpl implements 
         addDataToPrepareModel(documentUploadAttribute, submissionApi, formTemplate, uploadedFiles);
         addDynamicHintText(documentUploadAttribute, formTemplate.getFormCategory());
         model.mergeAttributes(documentUploadAttribute.getAttributes());
-        addTrackingAttributeToModel(model);
-        model.addAttribute("allowedFileExtensions", documentUploadAttribute.getAllowedFileExtensions());
-        model.addAttribute("formType", formTemplate.getFormType());
-        model.addAttribute("messageTextList", formTemplate.getMessageTexts());
-        logger.debug(String.format("Adding text fragments: %s", formTemplate.getMessageTexts()));
+        addDataToModel(documentUploadAttribute, model, formTemplate);
 
         return ViewConstants.DOCUMENT_UPLOAD.asView();
     }
@@ -138,7 +134,7 @@ public class DocumentUploadControllerImpl extends BaseControllerImpl implements 
 
         model.mergeAttributes(documentUploadAttribute.getAttributes());
         if (!verifySubmission(submissionApi)) {
-            model.addAttribute("messageTextList", formTemplate.getMessageTexts());
+            addDataToModel(documentUploadAttribute, model, formTemplate);
             return ViewConstants.ERROR.asView();
         }
 
@@ -152,8 +148,7 @@ public class DocumentUploadControllerImpl extends BaseControllerImpl implements 
             .stream().collect(Collectors.toMap(file -> fileTransferApiClient.upload(file).getFileId(), file -> file));
 
         if (binding.hasErrors()) {
-            addTrackingAttributeToModel(model);
-            model.addAttribute("messageTextList", formTemplate.getMessageTexts());
+            addDataToModel(documentUploadAttribute, model, formTemplate);
             return ViewConstants.DOCUMENT_UPLOAD.asView();
         }
 
@@ -196,8 +191,7 @@ public class DocumentUploadControllerImpl extends BaseControllerImpl implements 
         if (files == null || files.getFiles().isEmpty()) {
             String message = resourceBundle.getString("no_file_selected.documentUpload");
             binding.rejectValue("selectedFiles", "error.minimum-file-limit", message);
-            addTrackingAttributeToModel(model);
-            model.addAttribute("messageTextList", formTemplate.getMessageTexts());
+            addDataToModel(documentUploadAttribute, model, formTemplate);
             return ViewConstants.DOCUMENT_UPLOAD.asView();
         }
 
@@ -224,7 +218,7 @@ public class DocumentUploadControllerImpl extends BaseControllerImpl implements 
         final SubmissionApi submissionApi, @NonNull FormTemplateApi formTemplate, final FileListApi uploadedFiles) {
         final boolean isFesEnabled = formTemplate.isFesEnabled();
 
-        /**
+        /*
          * Have to ascertain how many uploads can be supplied as part of a submission.
          * Depending on the type of form we are using, we may need to override the basic
          * configuration to restrict it to a single file (for FES enabled forms).
@@ -247,5 +241,13 @@ public class DocumentUploadControllerImpl extends BaseControllerImpl implements 
                 == CategoryTypeConstants.CHANGE_OF_CONSTITUTION);
     }
 
+    private void addDataToModel(@ModelAttribute(ATTRIBUTE_NAME) final DocumentUploadModel documentUploadAttribute,
+        final Model model, final FormTemplateApi formTemplate) {
+        model.addAttribute("allowedFileExtensions", documentUploadAttribute.getAllowedFileExtensions());
+        model.addAttribute("formType", formTemplate.getFormType());
+        model.addAttribute("messageTextList", formTemplate.getMessageTexts());
+        logger.debug(String.format("Adding text fragments: %s", formTemplate.getMessageTexts()));
+        addTrackingAttributeToModel(model);
+    }
 
 }

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/DocumentUploadControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/DocumentUploadControllerImpl.java
@@ -134,9 +134,11 @@ public class DocumentUploadControllerImpl extends BaseControllerImpl implements 
         HttpServletRequest servletRequest, HttpSession session) {
 
         final SubmissionApi submissionApi = Objects.requireNonNull(getSubmission(id));
+        final FormTemplateApi formTemplate = getFormTemplateApi(submissionApi.getSubmissionForm().getFormType());
 
         model.mergeAttributes(documentUploadAttribute.getAttributes());
         if (!verifySubmission(submissionApi)) {
+            model.addAttribute("messageTextList", formTemplate.getMessageTexts());
             return ViewConstants.ERROR.asView();
         }
 
@@ -151,6 +153,7 @@ public class DocumentUploadControllerImpl extends BaseControllerImpl implements 
 
         if (binding.hasErrors()) {
             addTrackingAttributeToModel(model);
+            model.addAttribute("messageTextList", formTemplate.getMessageTexts());
             return ViewConstants.DOCUMENT_UPLOAD.asView();
         }
 

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/DocumentUploadControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/DocumentUploadControllerTest.java
@@ -326,6 +326,11 @@ class DocumentUploadControllerTest extends BaseControllerImplTest {
         when(sessionService.getSessionDataFromContext()).thenReturn(sessionContextData);
         when(sessionService.getUserEmail()).thenReturn(SIGNED_IN_USER);
 
+        FormTemplateApi formTemplateApi = mock(FormTemplateApi.class);
+        ApiResponse<FormTemplateApi> apiFormTypeResponse = mock(ApiResponse.class);
+        when(apiFormTypeResponse.getData()).thenReturn(formTemplateApi);
+        when(formTemplateService.getFormTemplate(FORM_TYPE_CODE)).thenReturn(apiFormTypeResponse);
+
         BindingResult binding = mock(BindingResult.class);
 
         String viewName = toTest.process(submissionID, companyNumber, documentUploadAttribute, binding, model, servletRequest, httpSession);
@@ -352,6 +357,11 @@ class DocumentUploadControllerTest extends BaseControllerImplTest {
         when(sessionService.getSessionDataFromContext()).thenReturn(sessionContextData);
         when(sessionService.getUserEmail()).thenReturn("wrong.user@ch.gov.uk");
 
+        FormTemplateApi formTemplateApi = mock(FormTemplateApi.class);
+        ApiResponse<FormTemplateApi> apiFormTypeResponse = mock(ApiResponse.class);
+        when(apiFormTypeResponse.getData()).thenReturn(formTemplateApi);
+        when(formTemplateService.getFormTemplate(FORM_TYPE_CODE)).thenReturn(apiFormTypeResponse);
+
         BindingResult binding = mock(BindingResult.class);
 
         String viewName = toTest.process(submissionID, companyNumber, documentUploadAttribute, binding, model, servletRequest, httpSession);
@@ -377,6 +387,11 @@ class DocumentUploadControllerTest extends BaseControllerImplTest {
 
         when(sessionService.getSessionDataFromContext()).thenReturn(sessionContextData);
         when(sessionService.getUserEmail()).thenReturn(SIGNED_IN_USER);
+
+        FormTemplateApi formTemplateApi = mock(FormTemplateApi.class);
+        ApiResponse<FormTemplateApi> apiFormTypeResponse = mock(ApiResponse.class);
+        when(apiFormTypeResponse.getData()).thenReturn(formTemplateApi);
+        when(formTemplateService.getFormTemplate(FORM_TYPE_CODE)).thenReturn(apiFormTypeResponse);
 
         BindingResult binding = mock(BindingResult.class);
         when(binding.hasErrors()).thenReturn(Boolean.TRUE);
@@ -407,6 +422,11 @@ class DocumentUploadControllerTest extends BaseControllerImplTest {
 
         when(sessionService.getSessionDataFromContext()).thenReturn(sessionContextData);
         when(sessionService.getUserEmail()).thenReturn(SIGNED_IN_USER);
+
+        FormTemplateApi formTemplateApi = mock(FormTemplateApi.class);
+        ApiResponse<FormTemplateApi> apiFormTypeResponse = mock(ApiResponse.class);
+        when(apiFormTypeResponse.getData()).thenReturn(formTemplateApi);
+        when(formTemplateService.getFormTemplate(FORM_TYPE_CODE)).thenReturn(apiFormTypeResponse);
 
         BindingResult binding = mock(BindingResult.class);
         when(binding.hasErrors()).thenReturn(Boolean.FALSE);

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/DocumentUploadControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/DocumentUploadControllerTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.efs.web.controller.DocumentUploadControllerImpl.FILE_UPLOADS_ALLOWED_FOR_FES_ENABLED_FORMS;
 
@@ -123,11 +124,7 @@ class DocumentUploadControllerTest extends BaseControllerImplTest {
         String submissionID = submissionApi.getId();
         String companyNumber = submissionApi.getCompany().getCompanyNumber();
 
-        ApiResponse<SubmissionApi> apiSubmissionResponse = mock(ApiResponse.class);
-        when(apiSubmissionResponse.getData()).thenReturn(submissionApi);
-        when(apiSubmissionResponse.getStatusCode()).thenReturn(200);
-
-        when(apiClientService.getSubmission(SUBMISSION_ID)).thenReturn(apiSubmissionResponse);
+        expectSubmissionID(submissionApi);
 
         FormTemplateApi formTemplateApi = mock(FormTemplateApi.class);
         when(formTemplateApi.isFesEnabled()).thenReturn(Boolean.FALSE);
@@ -151,8 +148,7 @@ class DocumentUploadControllerTest extends BaseControllerImplTest {
         String viewName = toTest.prepare(submissionID, companyNumber, documentUploadAttribute, model, servletRequest, httpSession);
 
         verifyDocumentAttribute(submissionApi, submissionID, 10, false);
-        verify(model).mergeAttributes(attributes);
-        verify(model).addAttribute(TEMPLATE_NAME, "documentUpload");
+        verifyModelAttributes(formTemplateApi);
         assertThat(viewName, is(ViewConstants.DOCUMENT_UPLOAD.asView()));
     }
 
@@ -163,11 +159,7 @@ class DocumentUploadControllerTest extends BaseControllerImplTest {
         String submissionID = submissionApi.getId();
         String companyNumber = submissionApi.getCompany().getCompanyNumber();
 
-        ApiResponse<SubmissionApi> apiSubmissionResponse = mock(ApiResponse.class);
-        when(apiSubmissionResponse.getData()).thenReturn(submissionApi);
-        when(apiSubmissionResponse.getStatusCode()).thenReturn(200);
-
-        when(apiClientService.getSubmission(SUBMISSION_ID)).thenReturn(apiSubmissionResponse);
+        expectSubmissionID(submissionApi);
 
         FormTemplateApi formTemplateApi = mock(FormTemplateApi.class);
         when(formTemplateApi.isFesEnabled()).thenReturn(Boolean.TRUE);
@@ -177,19 +169,14 @@ class DocumentUploadControllerTest extends BaseControllerImplTest {
 
         when(formTemplateService.getFormTemplate(FORM_TYPE_CODE)).thenReturn(apiFormTypeResponse);
 
-        Map<String, Object> sessionContextData = new HashMap<>();
-        sessionContextData.put(ORIGINAL_SUBMISSION_ID, SUBMISSION_ID);
-
-        when(sessionService.getSessionDataFromContext()).thenReturn(sessionContextData);
-        when(sessionService.getUserEmail()).thenReturn(SIGNED_IN_USER);
+        expectSignedInUser(submissionApi, SUBMISSION_ID, SIGNED_IN_USER);
 
         when(documentUploadAttribute.getAttributes()).thenReturn(attributes);
 
         String viewName = toTest.prepare(submissionID, companyNumber, documentUploadAttribute, model, servletRequest, httpSession);
 
         verifyDocumentAttribute(submissionApi, submissionID, FILE_UPLOADS_ALLOWED_FOR_FES_ENABLED_FORMS, false);
-        verify(model).mergeAttributes(attributes);
-        verify(model).addAttribute(TEMPLATE_NAME, "documentUpload");
+        verifyModelAttributes(formTemplateApi);
         assertThat(viewName, is(ViewConstants.DOCUMENT_UPLOAD.asView()));
     }
 
@@ -200,11 +187,7 @@ class DocumentUploadControllerTest extends BaseControllerImplTest {
         String submissionID = submissionApi.getId();
         String companyNumber = submissionApi.getCompany().getCompanyNumber();
 
-        ApiResponse<SubmissionApi> apiSubmissionResponse = mock(ApiResponse.class);
-        when(apiSubmissionResponse.getData()).thenReturn(submissionApi);
-        when(apiSubmissionResponse.getStatusCode()).thenReturn(200);
-
-        when(apiClientService.getSubmission(SUBMISSION_ID)).thenReturn(apiSubmissionResponse);
+        expectSubmissionID(submissionApi);
 
         FormTemplateApi formTemplateApi = mock(FormTemplateApi.class);
         when(formTemplateApi.isFesEnabled()).thenReturn(Boolean.TRUE);
@@ -215,19 +198,14 @@ class DocumentUploadControllerTest extends BaseControllerImplTest {
 
         when(formTemplateService.getFormTemplate(FORM_TYPE_CODE)).thenReturn(apiFormTypeResponse);
 
-        Map<String, Object> sessionContextData = new HashMap<>();
-        sessionContextData.put(ORIGINAL_SUBMISSION_ID, SUBMISSION_ID);
-
-        when(sessionService.getSessionDataFromContext()).thenReturn(sessionContextData);
-        when(sessionService.getUserEmail()).thenReturn(SIGNED_IN_USER);
+        expectSignedInUser(submissionApi, SUBMISSION_ID, SIGNED_IN_USER);
 
         when(documentUploadAttribute.getAttributes()).thenReturn(attributes);
 
         String viewName = toTest.prepare(submissionID, companyNumber, documentUploadAttribute, model, servletRequest, httpSession);
 
         verifyDocumentAttribute(submissionApi, submissionID, FILE_UPLOADS_ALLOWED_FOR_FES_ENABLED_FORMS, true);
-        verify(model).mergeAttributes(attributes);
-        verify(model).addAttribute(TEMPLATE_NAME, "documentUpload");
+        verifyModelAttributes(formTemplateApi);
         assertThat(viewName, is(ViewConstants.DOCUMENT_UPLOAD.asView()));
     }
 
@@ -239,17 +217,8 @@ class DocumentUploadControllerTest extends BaseControllerImplTest {
         String submissionID = submissionApi.getId();
         String companyNumber = submissionApi.getCompany().getCompanyNumber();
 
-        ApiResponse<SubmissionApi> apiSubmissionResponse = mock(ApiResponse.class);
-        when(apiSubmissionResponse.getData()).thenReturn(submissionApi);
-        when(apiSubmissionResponse.getStatusCode()).thenReturn(200);
-
-        when(apiClientService.getSubmission(SUBMISSION_ID)).thenReturn(apiSubmissionResponse);
-
-        Map<String, Object> sessionContextData = new HashMap<>();
-        sessionContextData.put(ORIGINAL_SUBMISSION_ID, "wrong-submission-id");
-
-        when(sessionService.getSessionDataFromContext()).thenReturn(sessionContextData);
-        when(sessionService.getUserEmail()).thenReturn(SIGNED_IN_USER);
+        expectSubmissionID(submissionApi);
+        expectSignedInUser(submissionApi, "wrong-submission-id", SIGNED_IN_USER);
 
         String viewName = toTest.prepare(submissionID, companyNumber, documentUploadAttribute, model, servletRequest, httpSession);
 
@@ -263,17 +232,8 @@ class DocumentUploadControllerTest extends BaseControllerImplTest {
         String submissionID = submissionApi.getId();
         String companyNumber = submissionApi.getCompany().getCompanyNumber();
 
-        ApiResponse<SubmissionApi> apiSubmissionResponse = mock(ApiResponse.class);
-        when(apiSubmissionResponse.getData()).thenReturn(submissionApi);
-        when(apiSubmissionResponse.getStatusCode()).thenReturn(200);
-
-        when(apiClientService.getSubmission(SUBMISSION_ID)).thenReturn(apiSubmissionResponse);
-
-        Map<String, Object> sessionContextData = new HashMap<>();
-        sessionContextData.put(ORIGINAL_SUBMISSION_ID, SUBMISSION_ID);
-
-        when(sessionService.getSessionDataFromContext()).thenReturn(sessionContextData);
-        when(sessionService.getUserEmail()).thenReturn("wrong.user@ch.gov.uk");
+        expectSubmissionID(submissionApi);
+        expectSignedInUser(submissionApi, SUBMISSION_ID, "wrong.user@ch.gov.uk");
 
         String viewName = toTest.prepare(submissionID, companyNumber, documentUploadAttribute, model, servletRequest, httpSession);
 
@@ -290,17 +250,8 @@ class DocumentUploadControllerTest extends BaseControllerImplTest {
         String submissionID = submissionApi.getId();
         String companyNumber = submissionApi.getCompany().getCompanyNumber();
 
-        ApiResponse<SubmissionApi> apiSubmissionResponse = mock(ApiResponse.class);
-        when(apiSubmissionResponse.getData()).thenReturn(submissionApi);
-        when(apiSubmissionResponse.getStatusCode()).thenReturn(200);
-
-        when(apiClientService.getSubmission(SUBMISSION_ID)).thenReturn(apiSubmissionResponse);
-
-        Map<String, Object> sessionContextData = new HashMap<>();
-        sessionContextData.put(ORIGINAL_SUBMISSION_ID, SUBMISSION_ID);
-
-        when(sessionService.getSessionDataFromContext()).thenReturn(sessionContextData);
-        when(sessionService.getUserEmail()).thenReturn(SIGNED_IN_USER);
+        expectSubmissionID(submissionApi);
+        expectSignedInUser(submissionApi, SUBMISSION_ID, SIGNED_IN_USER);
 
         String viewName = toTest.prepare(submissionID, companyNumber, documentUploadAttribute, model, servletRequest, httpSession);
 
@@ -314,17 +265,8 @@ class DocumentUploadControllerTest extends BaseControllerImplTest {
         String submissionID = submissionApi.getId();
         String companyNumber = submissionApi.getCompany().getCompanyNumber();
 
-        ApiResponse<SubmissionApi> apiSubmissionResponse = mock(ApiResponse.class);
-        when(apiSubmissionResponse.getData()).thenReturn(submissionApi);
-        when(apiSubmissionResponse.getStatusCode()).thenReturn(200);
-
-        when(apiClientService.getSubmission(SUBMISSION_ID)).thenReturn(apiSubmissionResponse);
-
-        Map<String, Object> sessionContextData = new HashMap<>();
-        sessionContextData.put(ORIGINAL_SUBMISSION_ID, "wrong-submission-id");
-
-        when(sessionService.getSessionDataFromContext()).thenReturn(sessionContextData);
-        when(sessionService.getUserEmail()).thenReturn(SIGNED_IN_USER);
+        expectSubmissionID(submissionApi);
+        expectSignedInUser(submissionApi, "wrong-submission-id", SIGNED_IN_USER);
 
         FormTemplateApi formTemplateApi = mock(FormTemplateApi.class);
         ApiResponse<FormTemplateApi> apiFormTypeResponse = mock(ApiResponse.class);
@@ -345,17 +287,8 @@ class DocumentUploadControllerTest extends BaseControllerImplTest {
         String submissionID = submissionApi.getId();
         String companyNumber = submissionApi.getCompany().getCompanyNumber();
 
-        ApiResponse<SubmissionApi> apiSubmissionResponse = mock(ApiResponse.class);
-        when(apiSubmissionResponse.getData()).thenReturn(submissionApi);
-        when(apiSubmissionResponse.getStatusCode()).thenReturn(200);
-
-        when(apiClientService.getSubmission(SUBMISSION_ID)).thenReturn(apiSubmissionResponse);
-
-        Map<String, Object> sessionContextData = new HashMap<>();
-        sessionContextData.put(ORIGINAL_SUBMISSION_ID, SUBMISSION_ID);
-
-        when(sessionService.getSessionDataFromContext()).thenReturn(sessionContextData);
-        when(sessionService.getUserEmail()).thenReturn("wrong.user@ch.gov.uk");
+        expectSubmissionID(submissionApi);
+        expectSignedInUser(submissionApi, SUBMISSION_ID, "wrong.user@ch.gov.uk");
 
         FormTemplateApi formTemplateApi = mock(FormTemplateApi.class);
         ApiResponse<FormTemplateApi> apiFormTypeResponse = mock(ApiResponse.class);
@@ -376,25 +309,10 @@ class DocumentUploadControllerTest extends BaseControllerImplTest {
         String submissionID = submissionApi.getId();
         String companyNumber = submissionApi.getCompany().getCompanyNumber();
 
-        ApiResponse<SubmissionApi> apiSubmissionResponse = mock(ApiResponse.class);
-        when(apiSubmissionResponse.getData()).thenReturn(submissionApi);
-        when(apiSubmissionResponse.getStatusCode()).thenReturn(200);
+        expectSubmissionID(submissionApi);
+        expectSignedInUser(submissionApi, SUBMISSION_ID, SIGNED_IN_USER);
 
-        when(apiClientService.getSubmission(SUBMISSION_ID)).thenReturn(apiSubmissionResponse);
-
-        Map<String, Object> sessionContextData = new HashMap<>();
-        sessionContextData.put(ORIGINAL_SUBMISSION_ID, SUBMISSION_ID);
-
-        when(sessionService.getSessionDataFromContext()).thenReturn(sessionContextData);
-        when(sessionService.getUserEmail()).thenReturn(SIGNED_IN_USER);
-
-        FormTemplateApi formTemplateApi = mock(FormTemplateApi.class);
-        ApiResponse<FormTemplateApi> apiFormTypeResponse = mock(ApiResponse.class);
-        when(apiFormTypeResponse.getData()).thenReturn(formTemplateApi);
-        when(formTemplateService.getFormTemplate(FORM_TYPE_CODE)).thenReturn(apiFormTypeResponse);
-
-        BindingResult binding = mock(BindingResult.class);
-        when(binding.hasErrors()).thenReturn(Boolean.TRUE);
+        BindingResult binding = expectFileValidationError(submissionApi, Boolean.TRUE);
 
         when(documentUploadValidator.apply(documentUploadAttribute, binding)).thenReturn(new ArrayList<>());
 
@@ -411,25 +329,10 @@ class DocumentUploadControllerTest extends BaseControllerImplTest {
         String submissionID = submissionApi.getId();
         String companyNumber = submissionApi.getCompany().getCompanyNumber();
 
-        ApiResponse<SubmissionApi> apiSubmissionResponse = mock(ApiResponse.class);
-        when(apiSubmissionResponse.getData()).thenReturn(submissionApi);
-        when(apiSubmissionResponse.getStatusCode()).thenReturn(200);
+        expectSubmissionID(submissionApi);
+        expectSignedInUser(submissionApi, SUBMISSION_ID, SIGNED_IN_USER);
 
-        when(apiClientService.getSubmission(SUBMISSION_ID)).thenReturn(apiSubmissionResponse);
-
-        Map<String, Object> sessionContextData = new HashMap<>();
-        sessionContextData.put(ORIGINAL_SUBMISSION_ID, SUBMISSION_ID);
-
-        when(sessionService.getSessionDataFromContext()).thenReturn(sessionContextData);
-        when(sessionService.getUserEmail()).thenReturn(SIGNED_IN_USER);
-
-        FormTemplateApi formTemplateApi = mock(FormTemplateApi.class);
-        ApiResponse<FormTemplateApi> apiFormTypeResponse = mock(ApiResponse.class);
-        when(apiFormTypeResponse.getData()).thenReturn(formTemplateApi);
-        when(formTemplateService.getFormTemplate(FORM_TYPE_CODE)).thenReturn(apiFormTypeResponse);
-
-        BindingResult binding = mock(BindingResult.class);
-        when(binding.hasErrors()).thenReturn(Boolean.FALSE);
+        BindingResult binding = expectFileValidationError(submissionApi, Boolean.FALSE);
 
         List<MultipartFile> uploadedFiles = new ArrayList<>();
         uploadedFiles.add(new MockMultipartFile("data", "testfile.txt", "text/plain", "some text".getBytes()));
@@ -471,15 +374,8 @@ class DocumentUploadControllerTest extends BaseControllerImplTest {
         String submissionID = submissionApi.getId();
         String companyNumber = submissionApi.getCompany().getCompanyNumber();
 
-        ApiResponse<SubmissionApi> apiSubmissionResponse = mock(ApiResponse.class);
-        when(apiSubmissionResponse.getData()).thenReturn(submissionApi);
-        when(apiSubmissionResponse.getStatusCode()).thenReturn(200);
-        when(apiClientService.getSubmission(SUBMISSION_ID)).thenReturn(apiSubmissionResponse);
-
-        FormTemplateApi formTemplateApi = mock(FormTemplateApi.class);
-        ApiResponse<FormTemplateApi> apiFormTypeResponse = mock(ApiResponse.class);
-        when(apiFormTypeResponse.getData()).thenReturn(formTemplateApi);
-        when(formTemplateService.getFormTemplate(FORM_TYPE_CODE)).thenReturn(apiFormTypeResponse);
+        expectSubmissionID(submissionApi);
+        expectFormTypeSelection(submissionApi);
 
         List<FileApi> fileList = new ArrayList<>();
         fileList.add(new FileApi("my-file-upload-response-guid", "testfile.txt", 9L));
@@ -500,15 +396,8 @@ class DocumentUploadControllerTest extends BaseControllerImplTest {
         String submissionID = submissionApi.getId();
         String companyNumber = submissionApi.getCompany().getCompanyNumber();
 
-        ApiResponse<SubmissionApi> apiSubmissionResponse = mock(ApiResponse.class);
-        when(apiSubmissionResponse.getData()).thenReturn(submissionApi);
-        when(apiSubmissionResponse.getStatusCode()).thenReturn(200);
-        when(apiClientService.getSubmission(SUBMISSION_ID)).thenReturn(apiSubmissionResponse);
-
-        FormTemplateApi formTemplateApi = mock(FormTemplateApi.class);
-        ApiResponse<FormTemplateApi> apiFormTypeResponse = mock(ApiResponse.class);
-        when(apiFormTypeResponse.getData()).thenReturn(formTemplateApi);
-        when(formTemplateService.getFormTemplate(FORM_TYPE_CODE)).thenReturn(apiFormTypeResponse);
+        expectSubmissionID(submissionApi);
+        expectFormTypeSelection(submissionApi);
 
         when(documentUploadAttribute.getDetails()).thenReturn(new FileListApi());
 
@@ -529,5 +418,47 @@ class DocumentUploadControllerTest extends BaseControllerImplTest {
         verify(documentUploadAttribute).setMaximumUploadLimitReached(false);
         verify(documentUploadAttribute).setDetails(new FileListApi());
         verify(documentUploadAttribute).addAttribute(CC_REMINDER, b);
+        verify(documentUploadAttribute).addAttribute(CC_REMINDER, b);
+    }
+
+    private void verifyModelAttributes(final FormTemplateApi formTemplateApi) {
+        verify(model).mergeAttributes(attributes);
+        verify(model).addAttribute(TEMPLATE_NAME, "documentUpload");
+        verify(model).addAttribute("allowedFileExtensions", documentUploadAttribute.getAllowedFileExtensions());
+        verify(model).addAttribute("formType", formTemplateApi.getFormType());
+        verify(model).addAttribute("messageTextList", formTemplateApi.getMessageTexts());
+    }
+
+    private void expectFormTypeSelection(final SubmissionApi submissionApi) {
+        FormTemplateApi formTemplateApi = mock(FormTemplateApi.class);
+        ApiResponse<FormTemplateApi> apiFormTypeResponse = mock(ApiResponse.class);
+        when(apiFormTypeResponse.getData()).thenReturn(formTemplateApi);
+        when(formTemplateService.getFormTemplate(FORM_TYPE_CODE)).thenReturn(apiFormTypeResponse);
+    }
+
+    private void expectSubmissionID(final SubmissionApi submissionApi) {
+        ApiResponse<SubmissionApi> apiSubmissionResponse = mock(ApiResponse.class);
+        when(apiSubmissionResponse.getData()).thenReturn(submissionApi);
+        when(apiSubmissionResponse.getStatusCode()).thenReturn(200);
+        when(apiClientService.getSubmission(SUBMISSION_ID)).thenReturn(apiSubmissionResponse);
+    }
+
+    private void expectSignedInUser(final SubmissionApi submissionApi, final String s, final String signedInUser) {
+        Map<String, Object> sessionContextData = new HashMap<>();
+        sessionContextData.put(ORIGINAL_SUBMISSION_ID, s);
+
+        when(sessionService.getSessionDataFromContext()).thenReturn(sessionContextData);
+        when(sessionService.getUserEmail()).thenReturn(signedInUser);
+    }
+
+    private BindingResult expectFileValidationError(final SubmissionApi submissionApi, final Boolean expectBindingErrors) {
+        FormTemplateApi formTemplateApi = mock(FormTemplateApi.class);
+        ApiResponse<FormTemplateApi> apiFormTypeResponse = mock(ApiResponse.class);
+        when(apiFormTypeResponse.getData()).thenReturn(formTemplateApi);
+        when(formTemplateService.getFormTemplate(FORM_TYPE_CODE)).thenReturn(apiFormTypeResponse);
+
+        BindingResult binding = mock(BindingResult.class);
+        when(binding.hasErrors()).thenReturn(expectBindingErrors);
+        return binding;
     }
 }


### PR DESCRIPTION
Other validation errors hadn't been accounted for and had the `messageTextList` attribute added for redisplay.

BI-6835

<img width="523" alt="Screenshot 2021-02-05 at 13 32 47" src="https://user-images.githubusercontent.com/2736331/107040083-a67f4700-67b6-11eb-96b0-a773320c0040.png">
