### PR TITLE
Added logging ResponseStatusExceptions

### DIFF
--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/GlobalExceptionHandler.java
@@ -1,24 +1,72 @@
 package uk.gov.companieshouse.efs.web.controller;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import uk.gov.companieshouse.logging.Logger;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @ControllerAdvice
+@Component
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+    private final Logger logger;
+    private static final Pattern submissionID = Pattern.compile("[0-9a-fA-F]{24}");
+
+    @Autowired
+    public GlobalExceptionHandler(Logger logger) {
+        this.logger = logger;
+    }
 
     private static final String SERVICE_PROBLEM_PAGE = ViewConstants.ERROR.asView();
 
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR) // 500
+
     @ExceptionHandler(ResponseStatusException.class)
-    public String handleStatusErrorResponse(final ResponseStatusException ex) {
+    public String handleStatusErrorResponseWithSubmissionId(HttpServletRequest request,
+                                            final ResponseStatusException ex) {
+
+        String submissionID = submissionIDFromURI(request.getRequestURI());
+        logResponseStatusException(ex, submissionID);
+
         return SERVICE_PROBLEM_PAGE;
+    }
+
+    private void logResponseStatusException(ResponseStatusException ex, final String submissionID) {
+        Map<String, Object> logDetails = new HashMap<>();
+        logDetails.put("statusCode", ex.getStatus().value());
+        logDetails.put("statusMessage", ex.getStatus().getReasonPhrase());
+
+        logger.errorContext(submissionID, "Received non 200 series response from API",
+                ex, logDetails);
+    }
+
+    /**
+     * Retrieves the submissionID from the request URI by matching with a regular expression that
+     * matches mongo objects which is what is being used for the submission ID's
+     *
+     * @param uri - The reuest URI
+     * @return - The submissionID. It will be an empty string if there was no submissionID
+     */
+    private static String submissionIDFromURI(final String uri) {
+        Matcher submissionIDMatcher = submissionID.matcher(uri);
+        if (!submissionIDMatcher.find()) {
+            return "";
+        }
+
+        return submissionIDMatcher.group();
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/NewSubmissionControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/NewSubmissionControllerImpl.java
@@ -67,20 +67,16 @@ public class NewSubmissionControllerImpl extends BaseControllerImpl implements N
             logger.errorRequest(request, "Company number in URL does not match companyDetailAttribute.companyNumber");
             return ViewConstants.ERROR.asView();
         }
-        try {
-            newSubmissionId = createNewSubmission();
 
-            ApiResponse<SubmissionResponseApi> response = apiClientService.putCompany(newSubmissionId,
-                new CompanyApi(companyDetailAttribute.getCompanyNumber(), companyDetailAttribute.getCompanyName()));
+        newSubmissionId = createNewSubmission();
 
-            logApiResponse(response, "",
-                MessageFormat.format("PUT /efs-submission-api/submission/{0}/company", newSubmissionId));
-            storeOriginalSubmissionId(newSubmissionId);
+        ApiResponse<SubmissionResponseApi> response = apiClientService.putCompany(newSubmissionId,
+            new CompanyApi(companyDetailAttribute.getCompanyNumber(), companyDetailAttribute.getCompanyName()));
 
-        } catch (RuntimeException ex) {
-            logger.errorRequest(request, ex.getMessage(), ex);
-            return ViewConstants.ERROR.asView();
-        }
+        logApiResponse(response, "",
+            MessageFormat.format("PUT /efs-submission-api/submission/{0}/company", newSubmissionId));
+        storeOriginalSubmissionId(newSubmissionId);
+
 
         return ViewConstants.CATEGORY_SELECTION
             .asRedirectUri(chsUrl, newSubmissionId, companyDetailAttribute.getCompanyNumber());

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/NewSubmissionControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/NewSubmissionControllerImpl.java
@@ -47,14 +47,11 @@ public class NewSubmissionControllerImpl extends BaseControllerImpl implements N
         String newSubmissionId;
 
         companyDetailAttribute.clear();
-        try {
-            newSubmissionId = createNewSubmission();
-            companyDetailAttribute.setSubmissionId(newSubmissionId);
-            storeOriginalSubmissionId(newSubmissionId);
-        } catch (RuntimeException ex) {
-            logger.errorRequest(request, ex.getMessage(), ex);
-            return ViewConstants.ERROR.asView();
-        }
+
+        newSubmissionId = createNewSubmission();
+        companyDetailAttribute.setSubmissionId(newSubmissionId);
+        storeOriginalSubmissionId(newSubmissionId);
+
         attributes.addAttribute("forward",
             String.format("/efs-submission/%s/company/{companyNumber}/details", newSubmissionId));
 

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/CompanyDetailControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/CompanyDetailControllerImplTest.java
@@ -44,7 +44,7 @@ class CompanyDetailControllerImplTest extends BaseControllerImplTest {
         ((CompanyDetailControllerImpl) testController).setChsUrl(CHS_URL);
 
         mockMvc = MockMvcBuilders.standaloneSetup(testController)
-                .setControllerAdvice(new GlobalExceptionHandler())
+                .setControllerAdvice(new GlobalExceptionHandler(logger))
                 .build();
     }
 

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/NewSubmissionControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/NewSubmissionControllerImplTest.java
@@ -141,7 +141,6 @@ class NewSubmissionControllerImplTest extends BaseControllerImplTest {
 
         String newSubmissionUrl = "/efs-submission/new-submission/";
         mockMvc.perform(get(newSubmissionUrl).flashAttr("companyDetail", companyDetail))
-                .andExpect(status().is(status.value()))
                 .andReturn();
 
         ArgumentCaptor<Map<String, Object>> logDetailsCapture = ArgumentCaptor.forClass(Map.class);


### PR DESCRIPTION
Added logging in the GlobalExceptionHandler so that response statuses are logged correctly.
Also, removed some catch blocks that were preventing the exception from hitting the exception handler and fixed a related test.

[BI-6636](https://companieshouse.atlassian.net/browse/BI-6636)