### PR TITLE
Fixed "no main manifest attribute"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,9 @@
                 <configuration>
                     <!--suppress UnresolvedMavenProperty -->
                     <argLine>${failsafeArgLine}</argLine>
+
+                    <!--This is a workaround for failsafe not running integration tests-->
+                    <!-- https://stackoverflow.com/a/52532095 -->
                     <classesDirectory>${project.build.outputDirectory}</classesDirectory>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -223,9 +223,6 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring-boot-maven-plugin.version}</version>
-                <configuration>
-                    <classifier>exec</classifier>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>
@@ -255,6 +252,7 @@
                 <configuration>
                     <!--suppress UnresolvedMavenProperty -->
                     <argLine>${failsafeArgLine}</argLine>
+                    <classesDirectory>${project.build.outputDirectory}</classesDirectory>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Changes to the pom lead to two different jars being generated and only one being executable. This PR fixes that, making the jar executable again.