### PR TITLE
Add cookie consent banner to EFS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>common-web-java</artifactId>
+            <version>unversioned</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <sdk-manager-java.version>1.5.10</sdk-manager-java.version>
         <rest-service-common-library.version>0.0.3</rest-service-common-library.version>
         <environment-reader-library.version>1.3.2</environment-reader-library.version>
+        <common-web-java.version>1.5.0</common-web-java.version>
         <commons-fileupload.version>1.4</commons-fileupload.version>
         <structured-logging.version>1.9.0</structured-logging.version>
 
@@ -207,7 +208,7 @@
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>common-web-java</artifactId>
-            <version>unversioned</version>
+            <version>${common-web-java.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -37,6 +37,7 @@ enquiries.mailbox=${ENQUIRIES_MAILBOX}
 govuk.call.charges.url=${GOVUK_CALL_CHARGES_URL}
 accessibility.digital.centre=${ACCESSIBILITY_DIGITAL_CENTRE}
 accessibility.equality.service=${ACCESSIBILITY_EQUALITY_SERVICE}
+cookie_consent=${COOKIE_CONSENT}
 
 # Spring Actuator
 management.endpoints.enabled-by-default=${MANAGEMENT_ENDPOINTS_ENABLED_BY_DEFAULT}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -37,7 +37,6 @@ enquiries.mailbox=${ENQUIRIES_MAILBOX}
 govuk.call.charges.url=${GOVUK_CALL_CHARGES_URL}
 accessibility.digital.centre=${ACCESSIBILITY_DIGITAL_CENTRE}
 accessibility.equality.service=${ACCESSIBILITY_EQUALITY_SERVICE}
-cookie_consent=${COOKIE_CONSENT}
 
 # Spring Actuator
 management.endpoints.enabled-by-default=${MANAGEMENT_ENDPOINTS_ENABLED_BY_DEFAULT}

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -9,7 +9,7 @@
         th:href="@{{cdnUrl}/stylesheets/js.css(cdnUrl=${@environment.getProperty('cdn.url')})}"
         media="all" rel="stylesheet" type="text/css" />
     <link
-        th:href="@{{cdnUrl}/stylesheets/govuk-frontend/v3.6.0/pre-assessment-govuk-frontend-3.6.0.min.css(cdnUrl=${@environment.getProperty('cdn.url')})}"
+        th:href="@{{cdnUrl}/stylesheets/govuk-frontend/v3.11.0/govuk-frontend-3.11.0.min.css(cdnUrl=${@environment.getProperty('cdn.url')})}"
         media="all" rel="stylesheet" type="text/css" />
     <link
         th:href="@{{cdnUrl}/images/favicon.ico(cdnUrl=${@environment.getProperty('cdn.url')})}"
@@ -17,6 +17,11 @@
     <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1.0">
     <title layout:title-pattern="$CONTENT_TITLE"></title>
     <div id="templateName" th:attr="data-id=${templateName}" hidden></div>
+    <script th:inline="javascript">
+        window.SERVICE_NAME = 'efs'
+        window.PIWIK_URL = [[${@environment.getProperty('piwik.url')}]];
+        window.PIWIK_SITE_ID = [[${@environment.getProperty('piwik.siteId')}]];
+    </script>
 </head>
 <body>
     <script th:src="@{{cdnUrl}/javascripts/app/body-js-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}"
@@ -24,16 +29,7 @@
     <script th:src="@{{cdnUrl}/javascripts/vendor/jquery-3.3.1.min.js(cdnUrl=${@environment.getProperty('cdn.url')})}"
             type="text/javascript"></script>
 
-    <th:block th:if="${@environment.getProperty('cookie_consent') == 'true'}">
-        <div th:replace="fragments/piwikWithCookieCheck :: piwikWithCookieCheck (moduleName = 'efs')"></div>
-        <div th:replace="fragments/piwikWithCookieCheck :: cookieBanner"></div>
-        <script th:src="@{{cdnUrl}/javascripts/app/cookie-consent/cookie-consent-1.0.0.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-<!--        <script th:src="@{{cdnUrl}/javascripts/app/cookie-consent/matomo-only-cookie-consent.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>-->
-<!--        <script th:src="@{{cdnUrl}/javascripts/app/cookie-consent/piwik-only-cookie-consent.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>-->
-    </th:block>
-    <th:block th:unless="${@environment.getProperty('cookie_consent') == 'true'}">
-        <div th:replace="fragments/piwik :: piwik"></div>
-    </th:block>
+    <div th:replace="fragments/piwikWithCookieCheck :: cookieBanner"></div>
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
     <div class="entire-wrapper">
@@ -50,12 +46,16 @@
             type="text/javascript"></script>
     <script th:src="@{{cdnUrl}/javascripts/vendor/application.js(cdnUrl=${@environment.getProperty('cdn.url')})}"
             type="text/javascript"></script>
-    <script th:src="@{{cdnUrl}/javascripts/govuk-frontend/v3.6.0/govuk-frontend-3.6.0.min.js(cdnUrl=${@environment.getProperty('cdn.url')})}"
+    <script th:src="@{{cdnUrl}/javascripts/govuk-frontend/v3.11.0/govuk-frontend-3.11.0.min.js(cdnUrl=${@environment.getProperty('cdn.url')})}"
             type="text/javascript"></script>
     <script type="text/javascript">window.GOVUKFrontend.initAll()</script>
     <script th:src="@{{cdnUrl}/javascripts/app/piwik-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}"
             type="text/javascript"></script>
     <script th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/details-polyfill.js(cdnUrl=${@environment.getProperty('cdn.url')})}"
+            type="text/javascript"></script>
+    <script th:src="@{{cdnUrl}/javascripts/app/cookie-consent/cookie-consent-1.0.0.js(cdnUrl=${@environment.getProperty('cdn.url')})}"
+            type="text/javascript"></script>
+    <script th:src="@{{cdnUrl}/javascripts/app/cookie-consent/matomo-only-cookie-consent.js(cdnUrl=${@environment.getProperty('cdn.url')})}"
             type="text/javascript"></script>
 
 </body>

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -20,7 +20,7 @@
     <script th:inline="javascript">
         window.SERVICE_NAME = 'efs'
         window.PIWIK_URL = [[${@environment.getProperty('piwik.url')}]];
-        window.PIWIK_SITE_ID = [[${@environment.getProperty('piwik.siteId')}]];
+        window.PIWIK_SITE_ID = [[${@environment.getProperty('piwik.site.id')}]];
     </script>
 </head>
 <body>

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -24,6 +24,15 @@
     <script th:src="@{{cdnUrl}/javascripts/vendor/jquery-3.3.1.min.js(cdnUrl=${@environment.getProperty('cdn.url')})}"
             type="text/javascript"></script>
 
+    <th:block th:if="${@environment.getProperty('cookie_consent') == 'true'}">
+        <div th:replace="fragments/piwikWithCookieCheck :: piwikWithCookieCheck (moduleName = 'efs')"></div>
+        <div th:replace="fragments/piwikWithCookieCheck :: cookieBanner"></div>
+        <script th:src="@{{cdnUrl}/javascripts/app/cookie-consent-poc.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+    </th:block>
+    <th:block th:unless="${@environment.getProperty('cookie_consent') == 'true'}">
+        <div th:replace="fragments/piwik :: piwik"></div>
+    </th:block>
+
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
     <div class="entire-wrapper">
         <div th:replace="fragments/header :: header"></div>
@@ -47,6 +56,5 @@
     <script th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/details-polyfill.js(cdnUrl=${@environment.getProperty('cdn.url')})}"
             type="text/javascript"></script>
 
-    <div th:replace="fragments/piwik :: piwik"></div>
 </body>
 </html>

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -27,7 +27,9 @@
     <th:block th:if="${@environment.getProperty('cookie_consent') == 'true'}">
         <div th:replace="fragments/piwikWithCookieCheck :: piwikWithCookieCheck (moduleName = 'efs')"></div>
         <div th:replace="fragments/piwikWithCookieCheck :: cookieBanner"></div>
-        <script th:src="@{{cdnUrl}/javascripts/app/cookie-consent-poc.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+        <script th:src="@{{cdnUrl}/javascripts/app/cookie-consent/cookie-consent-1.0.0.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+<!--        <script th:src="@{{cdnUrl}/javascripts/app/cookie-consent/matomo-only-cookie-consent.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>-->
+<!--        <script th:src="@{{cdnUrl}/javascripts/app/cookie-consent/piwik-only-cookie-consent.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>-->
     </th:block>
     <th:block th:unless="${@environment.getProperty('cookie_consent') == 'true'}">
         <div th:replace="fragments/piwik :: piwik"></div>


### PR DESCRIPTION
- Implemented developer's guidance page in confluence
- EFS live service uses matomo
- I have tested that data is passed to matomo test service only when cookie accepted
- when testing in docker cdn needs to be either in dev mode or image rebuilt

Please see docker change here https://github.com/companieshouse/docker-chs-development/pull/152

BI-6979