### PR TITLE
Renamed setup method in BaseControllerImplTest

### DIFF
--- a/src/test/java/uk/gov/companieshouse/efs/web/categorytemplates/controller/CategoryTemplateControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/categorytemplates/controller/CategoryTemplateControllerImplTest.java
@@ -68,10 +68,9 @@ public class CategoryTemplateControllerImplTest extends BaseControllerImplTest {
 
     private CategoryTemplateController testController;
 
-    @Override
     @BeforeEach
     protected void setUp() {
-        super.setUp();
+        setUpHeaders();
         testController = new CategoryTemplateControllerImpl(categoryTemplateService,
                 apiClientService, sessionService, formTemplateService, logger,
                 categoryTemplateAttribute);

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/BaseControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/BaseControllerImplTest.java
@@ -130,7 +130,7 @@ public abstract class BaseControllerImplTest {
     @Mock
     private SubmissionApi submission;
 
-    protected void setUp() {
+    protected void setUpHeaders() {
         headers = new HashMap<>();
     }
 

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/CheckDetailsControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/CheckDetailsControllerImplTest.java
@@ -40,7 +40,7 @@ class CheckDetailsControllerImplTest extends BaseControllerImplTest {
 
     @BeforeEach
     protected void setUp() {
-        super.setUp();
+        setUpHeaders();
         testController = new CheckDetailsControllerImpl(logger, sessionService, apiClientService, formTemplateService,
             categoryTemplateService, checkDetailsAttribute, confirmAuthorisedValidator);
         ((CheckDetailsControllerImpl) testController).setChsUrl(CHS_URL);

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/CompanyDetailControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/CompanyDetailControllerImplTest.java
@@ -38,7 +38,7 @@ class CompanyDetailControllerImplTest extends BaseControllerImplTest {
 
     @BeforeEach
     private void setup() {
-        super.setUp();
+        setUpHeaders();
         testController = new CompanyDetailControllerImpl(companyService, sessionService, apiClientService, logger,
                 companyDetailAttribute);
         ((CompanyDetailControllerImpl) testController).setChsUrl(CHS_URL);

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/ConfirmationControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/ConfirmationControllerImplTest.java
@@ -30,7 +30,7 @@ class ConfirmationControllerImplTest extends BaseControllerImplTest {
 
     @BeforeEach
     protected void setup() {
-        super.setUp();
+        setUpHeaders();
         testController = new ConfirmationControllerImpl(logger, sessionService,
                 apiClientService, formTemplateService, categoryTemplateService);
     }

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/DocumentUploadControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/DocumentUploadControllerTest.java
@@ -73,7 +73,7 @@ class DocumentUploadControllerTest extends BaseControllerImplTest {
 
     @BeforeEach
     private void start() {
-        super.setUp();
+        setUpHeaders();
 
         MockitoAnnotations.initMocks(this);
 

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/NewSubmissionControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/NewSubmissionControllerImplTest.java
@@ -52,7 +52,7 @@ class NewSubmissionControllerImplTest extends BaseControllerImplTest {
 
     @BeforeEach
     protected void setUp() {
-        super.setUp();
+        setUpHeaders();
         testController = new NewSubmissionControllerImpl(logger, sessionService, apiClientService);
         ((NewSubmissionControllerImpl) testController).setChsUrl(CHS_URL);
         company = new CompanyApi(COMPANY_NUMBER, COMPANY_NAME);

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/RemoveDocumentControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/RemoveDocumentControllerImplTest.java
@@ -68,7 +68,7 @@ class RemoveDocumentControllerImplTest extends BaseControllerImplTest {
 
     @BeforeEach
     protected void setUp() {
-        super.setUp();
+        setUpHeaders();
         testController = new RemoveDocumentControllerImpl(fileTransferApiClient, logger, sessionService,
                 apiClientService, removeDocumentAttribute);
     }

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/ResolutionsInfoControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/ResolutionsInfoControllerImplTest.java
@@ -30,7 +30,7 @@ class ResolutionsInfoControllerImplTest extends BaseControllerImplTest {
 
     @BeforeEach
     private void setup() {
-        super.setUp();
+        setUpHeaders();
         testController = new ResolutionsInfoControllerImpl(logger, sessionService, apiClientService,
             formTemplateService, categoryTemplateService);
         ((ResolutionsInfoControllerImpl) testController).setChsUrl(CHS_URL);

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImplTest.java
@@ -25,7 +25,7 @@ class StaticPageControllerImplTest extends BaseControllerImplTest {
 
     @BeforeEach
     protected void setUp() {
-        super.setUp();
+        setUpHeaders();
         testController = new StaticPageControllerImpl(logger);
         ((StaticPageControllerImpl) testController).setChsUrl(CHS_URL);
     }

--- a/src/test/java/uk/gov/companieshouse/efs/web/formtemplates/controller/FormTemplateControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/formtemplates/controller/FormTemplateControllerTest.java
@@ -73,10 +73,9 @@ class FormTemplateControllerTest extends BaseControllerImplTest {
     final static String SCOTTISH_COMPANY_NUMBER_2 = "SF000000";
     final static String SCOTTISH_COMPANY_NUMBER_3 = "SO000000";
 
-    @Override
     @BeforeEach
     protected void setUp() {
-        super.setUp();
+        setUpHeaders();
         testController = new FormTemplateControllerImpl(categoryTemplateService,
                 formTemplateService, apiClientService, sessionService, logger,
                 formTemplateAttribute);

--- a/src/test/java/uk/gov/companieshouse/efs/web/payment/controller/PaymentControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/payment/controller/PaymentControllerImplTest.java
@@ -46,10 +46,9 @@ class PaymentControllerImplTest extends BaseControllerImplTest {
     private SessionListApi paymentSessions;
     private SessionApi paySession;
 
-    @Override
     @BeforeEach
     public void setUp() {
-        super.setUp();
+        setUpHeaders();
         testController = new PaymentControllerImpl(apiClientService, paymentService, nonceService, logger);
         ((PaymentControllerImpl) testController).setChsUrl(CHS_URL);
         paymentSessions = new SessionListApi();


### PR DESCRIPTION
Method name in BaseControllerImplTest causing issues as it's similar to Junit setup method naming conventions but didn't do the same thing. This PR renames that method.

[BI-7113](https://companieshouse.atlassian.net/browse/BI-7113)