### PR TITLE
Stop 2 events sent to Matomo for validation errors

### DIFF
--- a/src/main/resources/templates/documentUpload.html
+++ b/src/main/resources/templates/documentUpload.html
@@ -32,7 +32,7 @@
                 <div id="file-upload-panel" th:unless="*{maximumUploadLimitReached}">
                     <div id="file-upload-wrapper" class="govuk-form-group" th:classappend="${#fields.hasErrors('*')} ? 'govuk-form-group--error' : ''">
                         <label class="govuk-label" for="file-uploader" th:text="#{documentUpload.header}"></label>
-                        <ul class="govuk-list govuk-error-summary__list">
+                        <ul class="govuk-list">
                             <li th:each="e: ${#lists.sort(#fields.detailedErrors(), errorComparator)}">
                                 <span id="selectedFiles-error" th:text="${e.message}" class="govuk-error-message"></span>
                             </li>


### PR DESCRIPTION
- remove class `govuk-error-summary__list` which should only be present in the error summary
- this was causing 2 events to be sent to Matomo - from the error summary at the top of the screen and alongside the field here.
- see the piwik-enable.js for reference to this class: https://github.com/companieshouse/cdn.ch.gov.uk/blob/master/app/assets/javascripts/app/piwik-enable.js#L166-L169

Before:
<img width="474" alt="Screenshot 2021-03-25 at 11 33 10" src="https://user-images.githubusercontent.com/2736331/112466655-ff527100-8d5d-11eb-96a7-3c70b4e696eb.png">

After:
<img width="468" alt="Screenshot 2021-03-25 at 11 33 25" src="https://user-images.githubusercontent.com/2736331/112466676-02e5f800-8d5e-11eb-8b64-6cb7c5f798ea.png">
