### PR TITLE
Increase maximum upload size to 6MB

### DIFF
--- a/src/main/java/uk/gov/companieshouse/efs/web/configuration/FileUploadConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/configuration/FileUploadConfiguration.java
@@ -33,7 +33,7 @@ public class FileUploadConfiguration {
      *
      * @param name configuraton name
      * @param allowedTypes allowed file types
-     * @param maximumFileSize maximum file size eg 4MB
+     * @param maximumFileSize maximum file size eg 6MB
      * @param maximumFilesAllowed eg 6
      */
     public FileUploadConfiguration(String name, List<FileType> allowedTypes, String maximumFileSize,

--- a/src/main/resources/file-upload.properties
+++ b/src/main/resources/file-upload.properties
@@ -3,5 +3,5 @@ file-upload.name=EFS
 file-upload.allowedTypes[0].mime=application/pdf
 file-upload.allowedTypes[0].extensions[0]=PDF
 
-file-upload.maximumFileSize=4MB
+file-upload.maximumFileSize=6MB
 file-upload.maximumFilesAllowed=10

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -165,7 +165,7 @@ guidance.documents.that.need.evidence.evidence2=The evidence we need for a servi
 guidance.documents.that.need.evidence.accept2.list.item1=written evidence of the start and end of the contract, which might include the applicant's request for service, an invoice that shows proof of payment or any other evidence of the company\u2019s direct involvement
 guidance.documents.that.need.evidence.accept2.list.item2=a copy of the signed contract and the termination letter
 guidance.how.to.prepare.the.document=How to prepare the document
-guidance.how.to.prepare.the.document.guide=You must complete the document in advance. Save it to the device you are using in a PDF format so that it is ready to upload. The file must be less than 4MB.
+guidance.how.to.prepare.the.document.guide=You must complete the document in advance. Save it to the device you are using in a PDF format so that it is ready to upload. The file must be less than 6MB.
 guidance.how.to.prepare.the.document.heading1=You can complete the form electronically:
 guidance.how.to.prepare.the.document.list.link=Find the Companies House form
 guidance.how.to.prepare.the.document.list1.item1=that you need and download it.
@@ -248,7 +248,7 @@ insolvency.guidance.documents.you.can.upload.form=form AD01
 insolvency.guidance.documents.you.can.upload.using=using this service.
 
 insolvency.guidance.prepare.document=How to prepare the document
-insolvency.guidance.prepare.document.para1=You must complete the document in advance. Save it to the device you are using in a PDF format so that it is ready to upload. The file must be less than 4MB.
+insolvency.guidance.prepare.document.para1=You must complete the document in advance. Save it to the device you are using in a PDF format so that it is ready to upload. The file must be less than 6MB.
 insolvency.guidance.prepare.document.inset.text=If you use a third party tool to compress your document, this may affect the quality of the document when it is uploaded. We may have to reject your document if the image quality is poor.
 insolvency.guidance.prepare.document.para2=You can only upload one document at a time. If you need to upload more than one document, for example as part of a package, you must start a new transaction for each document you upload.
 insolvency.guidance.signatures=Signatures

--- a/src/test/java/uk/gov/companieshouse/efs/web/validation/DocumentUploadValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/validation/DocumentUploadValidatorTest.java
@@ -138,7 +138,7 @@ class DocumentUploadValidatorTest {
     @Test
     void testMaximumFilesAlreadyUploaded() {
         when(fileUploadConfiguration.getMaximumFilesAllowed()).thenReturn(MAXIMUM_UPLOADS_ALLOWED);
-        when(fileUploadConfiguration.getMaximumFilesize()).thenReturn("4MB");
+        when(fileUploadConfiguration.getMaximumFilesize()).thenReturn("6MB");
         when(resourceBundle.getString("max_files_exceeded.documentUpload"))
                 .thenReturn("The selected file could not be uploaded. You can only attach up to {1} files");
 
@@ -166,7 +166,7 @@ class DocumentUploadValidatorTest {
         allowedTypes.add("PDF");
 
         when(fileUploadConfiguration.getMaximumFilesAllowed()).thenReturn(MAXIMUM_UPLOADS_ALLOWED);
-        when(fileUploadConfiguration.getMaximumFilesize()).thenReturn("4MB");
+        when(fileUploadConfiguration.getMaximumFilesize()).thenReturn("6MB");
         when(fileUploadConfiguration.getDistinctExtensions()).thenReturn(allowedTypes);
         when(resourceBundle.getString("invalid_file_type.documentUpload"))
                 .thenReturn("The selected file, {0}, must be {1}");
@@ -198,7 +198,7 @@ class DocumentUploadValidatorTest {
         allowedTypes.add(new FileUploadConfiguration.FileType(APPLICATION_PDF_VALUE, Arrays.asList(PDF_VALUE)));
 
         when(fileUploadConfiguration.getMaximumFilesAllowed()).thenReturn(MAXIMUM_UPLOADS_ALLOWED);
-        when(fileUploadConfiguration.getMaximumFilesize()).thenReturn("4MB");
+        when(fileUploadConfiguration.getMaximumFilesize()).thenReturn("6MB");
         when(fileUploadConfiguration.getDistinctMimeTypes()).thenReturn(
                 allowedTypes.stream().map(FileUploadConfiguration.FileType::getMime).collect(Collectors.toSet()));
         when(resourceBundle.getString("min_file_size_exceeded.documentUpload"))
@@ -231,13 +231,13 @@ class DocumentUploadValidatorTest {
         allowedTypes.add(new FileUploadConfiguration.FileType(APPLICATION_PDF_VALUE, Arrays.asList(PDF_VALUE)));
 
         when(fileUploadConfiguration.getMaximumFilesAllowed()).thenReturn(MAXIMUM_UPLOADS_ALLOWED);
-        when(fileUploadConfiguration.getMaximumFilesize()).thenReturn("4MB");
+        when(fileUploadConfiguration.getMaximumFilesize()).thenReturn("6MB");
         when(fileUploadConfiguration.getDistinctMimeTypes()).thenReturn(
                 allowedTypes.stream().map(FileUploadConfiguration.FileType::getMime).collect(Collectors.toSet()));
         when(resourceBundle.getString("max_file_size_exceeded.documentUpload"))
                 .thenReturn("The selected file must be smaller than {0}");
 
-        String fileContent = createContent(4 * KILOBYTE * KILOBYTE + 1);
+        String fileContent = createContent(6 * KILOBYTE * KILOBYTE + 1);
 
         DocumentUploadModel model = new DocumentUploadModel(fileUploadConfiguration);
         model.setDetails(createFiles(MINIMUM_UPLOADS_ALLOWED));
@@ -254,7 +254,7 @@ class DocumentUploadValidatorTest {
         FieldError fieldError = binding.getFieldError("selectedFiles");
         assert fieldError != null;
         assertThat(fieldError.getDefaultMessage(),
-                is("The selected file must be smaller than 4MB"));
+                is("The selected file must be smaller than 6MB"));
     }
 
     @Test
@@ -266,7 +266,7 @@ class DocumentUploadValidatorTest {
         allowedTypes.add(new FileUploadConfiguration.FileType(APPLICATION_PDF_VALUE, Arrays.asList(PDF_VALUE)));
 
         when(fileUploadConfiguration.getMaximumFilesAllowed()).thenReturn(MAXIMUM_UPLOADS_ALLOWED);
-        when(fileUploadConfiguration.getMaximumFilesize()).thenReturn("4MB");
+        when(fileUploadConfiguration.getMaximumFilesize()).thenReturn("6MB");
         when(fileUploadConfiguration.getDistinctMimeTypes()).thenReturn(
                 allowedTypes.stream().map(FileUploadConfiguration.FileType::getMime).collect(Collectors.toSet()));
         when(resourceBundle.getString("duplicate_file.documentUpload"))


### PR DESCRIPTION
- Increased config to allow 6MB files
- Changed guidance messages to say "6MB" instead of "4MB"
- Fixed tests to test for the new file size

Tested by compiling, running unit tests, checking the messages are correct in the dev environment, and that it passes WEB and API validation. 