### PR TITLE
The developer site has been redone and the url to access it has changed

### DIFF
--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -30,8 +30,7 @@
                         </li>
                         <li>
                             <a id="developer-link" class="govuk-footer__link" target="_blank"
-                               th:href="@{{developerUrl}/api/docs/(developerUrl=
-                                    ${@environment.getProperty('developer.url')})}"
+                               th:href="@{{developerUrl}(developerUrl=${@environment.getProperty('developer.url')})}"
                                th:text="#{footer.developers}">
                             </a>
                         </li>


### PR DESCRIPTION
There was 2 parts to this defect:
-  getting the new services running in tcats - https://developer.tcats1.aws.chdev.org
- removing the `/api/docs/` from the link

![Screenshot 2021-04-26 at 13 46 28](https://user-images.githubusercontent.com/2736331/116085009-49e54700-a696-11eb-9f77-f49986e5bffb.png)

BI-7669