### PR TITLE
Add sqp/slp reg link param to lookup URL

### DIFF
--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/CompanyDetailControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/CompanyDetailControllerImpl.java
@@ -4,6 +4,7 @@ import static uk.gov.companieshouse.efs.web.controller.CompanyDetailControllerIm
 
 import java.text.MessageFormat;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -67,6 +68,9 @@ public class CompanyDetailControllerImpl extends BaseControllerImpl implements C
     public String getCompanyDetail(final String id, final String companyNumber,
         final CompanyDetail companyDetailAttribute, final Model model, final HttpServletRequest request) {
 
+            if (StringUtils.equals(companyNumber, "noCompany")) {
+                return ViewConstants.MISSING.asView();
+            }
             companyDetailAttribute.setSubmissionId(id);
             companyService.getCompanyDetail(companyDetailAttribute, companyNumber);
 

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/CompanyDetailControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/CompanyDetailControllerImpl.java
@@ -71,7 +71,8 @@ public class CompanyDetailControllerImpl extends BaseControllerImpl implements C
     public String getCompanyDetail(final String id, final String companyNumber,
         final CompanyDetail companyDetailAttribute, final Model model, final HttpServletRequest request) {
 
-        if (registrationsEnabled && StringUtils.equals(companyNumber, "noCompany")) {
+        if (StringUtils.equals(companyNumber, "noCompany")) {
+            // Same result regardless of registrationsEnabled value, until proposed name view is added
             return ViewConstants.MISSING.asView();
         }
         companyDetailAttribute.setSubmissionId(id);

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/CompanyDetailControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/CompanyDetailControllerImpl.java
@@ -6,6 +6,7 @@ import java.text.MessageFormat;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -28,6 +29,8 @@ import uk.gov.companieshouse.logging.Logger;
  * setComplete() is properly called in ConfirmationControllerImpl at the end of the submission journey.
  */
 public class CompanyDetailControllerImpl extends BaseControllerImpl implements CompanyDetailController {
+    @Value("${registrations.enabled:false}")
+    private boolean registrationsEnabled;
 
     private final CompanyService companyService;
     private final CompanyDetail companyDetailAttribute;
@@ -68,10 +71,10 @@ public class CompanyDetailControllerImpl extends BaseControllerImpl implements C
     public String getCompanyDetail(final String id, final String companyNumber,
         final CompanyDetail companyDetailAttribute, final Model model, final HttpServletRequest request) {
 
-            if (StringUtils.equals(companyNumber, "noCompany")) {
-                return ViewConstants.MISSING.asView();
-            }
-            companyDetailAttribute.setSubmissionId(id);
+        if (registrationsEnabled && StringUtils.equals(companyNumber, "noCompany")) {
+            return ViewConstants.MISSING.asView();
+        }
+        companyDetailAttribute.setSubmissionId(id);
             companyService.getCompanyDetail(companyDetailAttribute, companyNumber);
 
         addTrackingAttributeToModel(model);

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/RegistrationsInfoControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/RegistrationsInfoControllerImpl.java
@@ -20,8 +20,6 @@ public class RegistrationsInfoControllerImpl extends BaseControllerImpl implemen
     @Value("${registrations.enabled:false}")
     private boolean registrationsEnabled;
 
-
-
     /**
      * Constructor used by child controllers.
      *

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImpl.java
@@ -67,7 +67,7 @@ public class StaticPageControllerImpl extends BaseControllerImpl implements Stat
         final RedirectAttributes attributes) {
         attributes.addAttribute("forward", String.format("/efs-submission/%s/company/{companyNumber}/details", id));
 
-        return UrlBasedViewResolver.REDIRECT_URL_PREFIX + chsUrl + "/company-lookup/search";
+        return UrlBasedViewResolver.REDIRECT_URL_PREFIX + chsUrl + "/company-lookup/search?noCompanyOption=1";
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImpl.java
@@ -1,7 +1,9 @@
 package uk.gov.companieshouse.efs.web.controller;
 
+import java.text.MessageFormat;
 import javax.servlet.ServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -21,6 +23,9 @@ import uk.gov.companieshouse.logging.Logger;
 @RequestMapping(BaseControllerImpl.SERVICE_URI)
 @SessionAttributes(CategoryTemplateControllerImpl.ATTRIBUTE_NAME)
 public class StaticPageControllerImpl extends BaseControllerImpl implements StaticPageController {
+    public static final String COMPANY_LOOKUP_SEARCH = "/company-lookup/search";
+    @Value("${registrations.enabled:false}")
+    private boolean registrationsEnabled;
 
     /**
      * Constructor.
@@ -67,7 +72,8 @@ public class StaticPageControllerImpl extends BaseControllerImpl implements Stat
         final RedirectAttributes attributes) {
         attributes.addAttribute("forward", String.format("/efs-submission/%s/company/{companyNumber}/details", id));
 
-        return UrlBasedViewResolver.REDIRECT_URL_PREFIX + chsUrl + "/company-lookup/search?noCompanyOption=1";
+        return MessageFormat.format("{0}{1}{2}{3}", UrlBasedViewResolver.REDIRECT_URL_PREFIX,
+            chsUrl, COMPANY_LOOKUP_SEARCH, registrationsEnabled ? "?noCompanyOption=1" : "");
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/CompanyDetailControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/CompanyDetailControllerImplTest.java
@@ -74,6 +74,26 @@ class CompanyDetailControllerImplTest extends BaseControllerImplTest {
     }
 
     @Test
+    void getCompanyDetailWhenFeatureEnabled() {
+        ReflectionTestUtils.setField(testController, "registrationsEnabled", true);
+
+        final String viewName = testController
+            .getCompanyDetail(SUBMISSION_ID, COMPANY_NUMBER, companyDetailAttribute, model, servletRequest);
+
+        verify(companyService).getCompanyDetail(companyDetailAttribute, COMPANY_NUMBER);
+        assertThat(viewName, is(ViewConstants.COMPANY_DETAIL.asView()));
+    }
+
+    @Test
+    void getCompanyDetailWhenFeatureDisabledNoCompany() {
+        final String viewName = testController
+            .getCompanyDetail(SUBMISSION_ID, "noCompany", companyDetailAttribute, model, servletRequest);
+
+        verifyNoInteractions(companyService);
+        assertThat(viewName, is(ViewConstants.MISSING.asView()));
+    }
+
+    @Test
     void getCompanyDetailWhenFeatureEnabledNoCompany() {
         ReflectionTestUtils.setField(testController, "registrationsEnabled", true);
         

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/CompanyDetailControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/CompanyDetailControllerImplTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.api.model.efs.submissions.CompanyApi;
@@ -43,6 +44,7 @@ class CompanyDetailControllerImplTest extends BaseControllerImplTest {
         testController = new CompanyDetailControllerImpl(companyService, sessionService, apiClientService, logger,
                 companyDetailAttribute);
         ((CompanyDetailControllerImpl) testController).setChsUrl(CHS_URL);
+        ReflectionTestUtils.setField(testController, "registrationsEnabled", false);
 
         mockMvc = MockMvcBuilders.standaloneSetup(testController)
                 .setControllerAdvice(new GlobalExceptionHandler(logger))
@@ -63,7 +65,7 @@ class CompanyDetailControllerImplTest extends BaseControllerImplTest {
     }
 
     @Test
-    void getCompanyDetail() {
+    void getCompanyDetailWhenFeatureDisabled() {
         final String viewName = testController
             .getCompanyDetail(SUBMISSION_ID, COMPANY_NUMBER, companyDetailAttribute, model, servletRequest);
 
@@ -72,7 +74,9 @@ class CompanyDetailControllerImplTest extends BaseControllerImplTest {
     }
 
     @Test
-    void getCompanyDetailWhenNoCompany() {
+    void getCompanyDetailWhenFeatureEnabledNoCompany() {
+        ReflectionTestUtils.setField(testController, "registrationsEnabled", true);
+        
         final String viewName = testController
             .getCompanyDetail(SUBMISSION_ID, "noCompany", companyDetailAttribute, model, servletRequest);
 

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/CompanyDetailControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/CompanyDetailControllerImplTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -68,6 +69,15 @@ class CompanyDetailControllerImplTest extends BaseControllerImplTest {
 
         verify(companyService).getCompanyDetail(companyDetailAttribute, COMPANY_NUMBER);
         assertThat(viewName, is(ViewConstants.COMPANY_DETAIL.asView()));
+    }
+
+    @Test
+    void getCompanyDetailWhenNoCompany() {
+        final String viewName = testController
+            .getCompanyDetail(SUBMISSION_ID, "noCompany", companyDetailAttribute, model, servletRequest);
+
+        verifyNoInteractions(companyService);
+        assertThat(viewName, is(ViewConstants.MISSING.asView()));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImplTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 
@@ -18,7 +19,7 @@ class StaticPageControllerImplTest extends BaseControllerImplTest {
 
     protected static final String COMPANY_SEARCH_REDIRECT =
         UrlBasedViewResolver.REDIRECT_URL_PREFIX + CHS_URL
-            + "/company-lookup/search?noCompanyOption=1";
+            + "/company-lookup/search";
     private StaticPageController testController;
 
     @Mock
@@ -29,6 +30,7 @@ class StaticPageControllerImplTest extends BaseControllerImplTest {
         setUpHeaders();
         testController = new StaticPageControllerImpl(logger);
         ((StaticPageControllerImpl) testController).setChsUrl(CHS_URL);
+        ReflectionTestUtils.setField(testController, "registrationsEnabled", false);
     }
 
     @Test
@@ -53,12 +55,23 @@ class StaticPageControllerImplTest extends BaseControllerImplTest {
     }
 
     @Test
-    void companyLookup() {
+    void companyLookupWhenFeatureDisabled() {
         final String view = testController.companyLookup(SUBMISSION_ID, model, servletRequest, attributes);
 
         verify(attributes)
             .addAttribute("forward", "/efs-submission/" + SUBMISSION_ID + "/company/{companyNumber}/details");
         assertThat(view, is(COMPANY_SEARCH_REDIRECT));
+    }
+    
+    @Test
+    void companyLookupWhenFeatureEnabled() {
+        ReflectionTestUtils.setField(testController, "registrationsEnabled", true);
+
+        final String view = testController.companyLookup(SUBMISSION_ID, model, servletRequest, attributes);
+
+        verify(attributes)
+            .addAttribute("forward", "/efs-submission/" + SUBMISSION_ID + "/company/{companyNumber}/details");
+        assertThat(view, is(COMPANY_SEARCH_REDIRECT + "?noCompanyOption=1"));
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImplTest.java
@@ -17,7 +17,8 @@ import org.springframework.web.servlet.view.UrlBasedViewResolver;
 class StaticPageControllerImplTest extends BaseControllerImplTest {
 
     protected static final String COMPANY_SEARCH_REDIRECT =
-        UrlBasedViewResolver.REDIRECT_URL_PREFIX + CHS_URL + "/company-lookup/search";
+        UrlBasedViewResolver.REDIRECT_URL_PREFIX + CHS_URL
+            + "/company-lookup/search?noCompanyOption=1";
     private StaticPageController testController;
 
     @Mock


### PR DESCRIPTION
- use noCompanyOption flag of company lookup web service
- show 404 page not found in efs web when company lookup link is used