### PR TITLE
Add proposed company name screen

### DIFF
--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/CompanyDetailControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/CompanyDetailControllerImpl.java
@@ -4,6 +4,7 @@ import static uk.gov.companieshouse.efs.web.controller.CompanyDetailControllerIm
 
 import java.text.MessageFormat;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -67,6 +68,9 @@ public class CompanyDetailControllerImpl extends BaseControllerImpl implements C
     public String getCompanyDetail(final String id, final String companyNumber,
         final CompanyDetail companyDetailAttribute, final Model model, final HttpServletRequest request) {
 
+            if (StringUtils.equals(companyNumber, "noCompany")) {
+                return ViewConstants.PROPOSED_COMPANY.asRedirectUri(chsUrl, id, "noCompany");
+            }
             companyDetailAttribute.setSubmissionId(id);
             companyService.getCompanyDetail(companyDetailAttribute, companyNumber);
 

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/ProposedCompanyController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/ProposedCompanyController.java
@@ -1,0 +1,29 @@
+package uk.gov.companieshouse.efs.web.controller;
+
+import static uk.gov.companieshouse.efs.web.controller.ProposedCompanyControllerImpl.ATTRIBUTE_NAME;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import uk.gov.companieshouse.efs.web.model.ProposedCompanyModel;
+
+@RequestMapping(BaseControllerImpl.SERVICE_URI)
+public interface ProposedCompanyController {
+
+    @GetMapping("{id}/company/noCompany/proposed-company")
+    String prepare(@PathVariable final String id,
+        @ModelAttribute(ATTRIBUTE_NAME) ProposedCompanyModel proposedCompanyModel, Model model,
+        HttpServletRequest request);
+
+    @PostMapping("{id}/company/noCompany/proposed-company")
+    String process(@PathVariable final String id,
+        @ModelAttribute(ATTRIBUTE_NAME) ProposedCompanyModel proposedCompanyModel,
+        BindingResult binding, Model model, HttpServletRequest request, HttpSession session);
+
+}

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/ProposedCompanyControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/ProposedCompanyControllerImpl.java
@@ -62,9 +62,8 @@ public class ProposedCompanyControllerImpl extends BaseControllerImpl implements
         }
         // Assign our previously saved response to our model.
         proposedCompany.setSubmissionId(id);
-        proposedCompany.setDetails(
-            new CompanyApi(TEMP_COMPANY_NUMBER, proposedCompanyAttribute.getName()));
-        proposedCompany.setNameRequired(null);
+        proposedCompany.setNumber(TEMP_COMPANY_NUMBER);
+        proposedCompany.setName(proposedCompanyAttribute.getName());
 
         return getViewName();
     }
@@ -85,7 +84,11 @@ public class ProposedCompanyControllerImpl extends BaseControllerImpl implements
         // Update our persistent model with the latest response.
         resetNameRequiredIfNotUsed(proposedCompany);
 
-        return ViewConstants.CATEGORY_SELECTION.asRedirectUri(chsUrl, id, proposedCompany.getNumber());
+        return Boolean.TRUE.equals(proposedCompanyAttribute.getNameRequired())
+            ? ViewConstants.CATEGORY_SELECTION.asRedirectUri(chsUrl, id,
+            proposedCompany.getNumber())
+            : ViewConstants.REGISTRATIONS_INFO.asRedirectUri(chsUrl, id,
+                proposedCompany.getNumber());
     }
 
     private void resetNameRequiredIfNotUsed(final ProposedCompanyModel proposedCompany) {

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/ProposedCompanyControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/ProposedCompanyControllerImpl.java
@@ -1,0 +1,76 @@
+package uk.gov.companieshouse.efs.web.controller;
+
+import static uk.gov.companieshouse.efs.web.controller.ProposedCompanyControllerImpl.ATTRIBUTE_NAME;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import javax.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.SessionAttributes;
+import uk.gov.companieshouse.efs.web.model.ProposedCompanyModel;
+import uk.gov.companieshouse.efs.web.service.api.ApiClientService;
+import uk.gov.companieshouse.efs.web.service.session.SessionService;
+import uk.gov.companieshouse.logging.Logger;
+
+@Controller
+@SessionAttributes(ATTRIBUTE_NAME)
+public class ProposedCompanyControllerImpl extends BaseControllerImpl implements ProposedCompanyController {
+
+    /**
+     * Define the model name for this action.
+     */
+    public static final String ATTRIBUTE_NAME = "proposedCompany";
+    public static final String TEMP_COMPANY_NUMBER = "99999999";
+    
+    private ProposedCompanyModel proposedCompanyAttribute;
+
+    @Autowired
+    public ProposedCompanyControllerImpl(final Logger logger, final SessionService sessionService,
+        final ApiClientService apiClientService, final ProposedCompanyModel proposedCompanyAttribute) {
+        super(logger, sessionService, apiClientService);
+
+        this.proposedCompanyAttribute = proposedCompanyAttribute;
+    }
+
+    @ModelAttribute(ATTRIBUTE_NAME)
+    public ProposedCompanyModel getModel() {
+        return proposedCompanyAttribute;
+    }
+
+    @Override
+    public String getViewName() {
+        return ViewConstants.PROPOSED_COMPANY.asView();
+    }
+
+    @Override
+    public String prepare(@PathVariable final String id,
+        @ModelAttribute(ATTRIBUTE_NAME) ProposedCompanyModel proposedCompanyModel, Model model,
+        HttpServletRequest request) {
+
+        // Assign our previously saved response to our model.
+        proposedCompanyModel.setSubmissionId(id);
+        proposedCompanyModel.setName(proposedCompanyAttribute.getName());
+
+        return getViewName();
+    }
+
+    @Override
+    public String process(@PathVariable final String id,
+        @Valid @ModelAttribute(ATTRIBUTE_NAME) ProposedCompanyModel proposedCompanyModel,
+        BindingResult binding, Model model, HttpServletRequest request, HttpSession session) {
+
+        if (binding.hasErrors()) {
+            return getViewName();
+        }
+
+        // Update our persistent model with the latest response.
+        proposedCompanyAttribute.setName(proposedCompanyModel.getName());
+
+        return ViewConstants.CATEGORY_SELECTION.asRedirectUri(chsUrl, id, TEMP_COMPANY_NUMBER);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/ProposedCompanyControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/ProposedCompanyControllerImpl.java
@@ -14,7 +14,6 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.SessionAttributes;
-import uk.gov.companieshouse.api.model.efs.submissions.CompanyApi;
 import uk.gov.companieshouse.efs.web.model.ProposedCompanyModel;
 import uk.gov.companieshouse.efs.web.service.api.ApiClientService;
 import uk.gov.companieshouse.efs.web.service.session.SessionService;
@@ -22,6 +21,12 @@ import uk.gov.companieshouse.logging.Logger;
 
 @Controller
 @SessionAttributes(ATTRIBUTE_NAME)
+@SuppressWarnings("squid:S3753")
+/* S3753: "@Controller" classes that use "@SessionAttributes" must call "setComplete" on their "SessionStatus" objects
+ *
+ * The nature of the web journey across several controllers means it's not appropriate to do this. However,
+ * setComplete() is properly called in ConfirmationControllerImpl at the end of the submission journey.
+ */
 public class ProposedCompanyControllerImpl extends BaseControllerImpl implements ProposedCompanyController {
     @Value("${registrations.enabled:false}")
     private boolean registrationsEnabled;

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/ProposedCompanyControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/ProposedCompanyControllerImpl.java
@@ -7,6 +7,7 @@ import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -22,6 +23,8 @@ import uk.gov.companieshouse.logging.Logger;
 @Controller
 @SessionAttributes(ATTRIBUTE_NAME)
 public class ProposedCompanyControllerImpl extends BaseControllerImpl implements ProposedCompanyController {
+    @Value("${registrations.enabled:false}")
+    private boolean registrationsEnabled;
 
     /**
      * Define the model name for this action.
@@ -54,6 +57,9 @@ public class ProposedCompanyControllerImpl extends BaseControllerImpl implements
         @ModelAttribute(ATTRIBUTE_NAME) ProposedCompanyModel proposedCompany, Model model,
         HttpServletRequest request) {
 
+        if (!registrationsEnabled) {
+            return ViewConstants.MISSING.asView();
+        }
         // Assign our previously saved response to our model.
         proposedCompany.setSubmissionId(id);
         proposedCompany.setDetails(
@@ -68,6 +74,9 @@ public class ProposedCompanyControllerImpl extends BaseControllerImpl implements
         @Valid @ModelAttribute(ATTRIBUTE_NAME) ProposedCompanyModel proposedCompany,
         BindingResult binding, Model model, HttpServletRequest request, HttpSession session) {
 
+        if (!registrationsEnabled) {
+            return ViewConstants.MISSING.asView();
+        }
         if (binding.hasErrors()) {
             addTrackingAttributeToModel(model);
             return getViewName();

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImpl.java
@@ -67,7 +67,7 @@ public class StaticPageControllerImpl extends BaseControllerImpl implements Stat
         final RedirectAttributes attributes) {
         attributes.addAttribute("forward", String.format("/efs-submission/%s/company/{companyNumber}/details", id));
 
-        return UrlBasedViewResolver.REDIRECT_URL_PREFIX + chsUrl + "/company-lookup/search";
+        return UrlBasedViewResolver.REDIRECT_URL_PREFIX + chsUrl + "/company-lookup/search?noCompanyOption=1";
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImpl.java
@@ -67,7 +67,7 @@ public class StaticPageControllerImpl extends BaseControllerImpl implements Stat
         final RedirectAttributes attributes) {
         attributes.addAttribute("forward", String.format("/efs-submission/%s/company/{companyNumber}/details", id));
 
-        return UrlBasedViewResolver.REDIRECT_URL_PREFIX + chsUrl + "/company-lookup/search?noCompanyOption=1";
+        return UrlBasedViewResolver.REDIRECT_URL_PREFIX + chsUrl + "/company-lookup/search";
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/ViewConstants.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/ViewConstants.java
@@ -15,6 +15,7 @@ public enum ViewConstants {
     NEW_SUBMISSION("new-submission", null),
     COMPANY_LOOKUP("companyLookup", null),
     COMPANY_DETAIL("details", "companyDetail"),
+    PROPOSED_COMPANY("proposed-company", "proposedCompany"),
     CATEGORY_SELECTION("category-selection", "categorySelection"),
     DOCUMENT_SELECTION("document-selection", "documentSelection"),
     RESOLUTIONS_INFO("resolutions-info", "resolutionsInfo"),

--- a/src/main/java/uk/gov/companieshouse/efs/web/model/ProposedCompanyModel.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/model/ProposedCompanyModel.java
@@ -19,6 +19,7 @@ public class ProposedCompanyModel {
 
     @SuppressWarnings("squid:S2637") // nameRequired initially null by design
     public ProposedCompanyModel() {
+        this.details = new CompanyApi();
     }
 
     @SuppressWarnings("squid:S2637") // nameRequired initially null by design

--- a/src/main/java/uk/gov/companieshouse/efs/web/model/ProposedCompanyModel.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/model/ProposedCompanyModel.java
@@ -7,29 +7,34 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.annotation.SessionScope;
+import uk.gov.companieshouse.api.model.efs.submissions.CompanyApi;
 
 @Component
 @SessionScope
 public class ProposedCompanyModel {
 
     private String submissionId;
-    private String name;
-    @NotNull(message = "{proposedCompany.blank.error}")
     private Boolean nameRequired;
+    private CompanyApi details;
 
+    @SuppressWarnings("squid:S2637") // nameRequired initially null by design
     public ProposedCompanyModel() {
-        this.name = "";
     }
 
-    /**
-     * Constructor sets the required value from the {@link ProposedCompanyModel}
-     *
-     * @param original the {@link ProposedCompanyModel}
-     */
-    public ProposedCompanyModel(final ProposedCompanyModel original) {
-        this.submissionId = original.getSubmissionId();
-        this.name = original.getName();
-        this.nameRequired = original.getNameRequired();
+    @SuppressWarnings("squid:S2637") // nameRequired initially null by design
+    public ProposedCompanyModel(final CompanyApi details) {
+        this.details = details;
+    }
+
+    public ProposedCompanyModel(final CompanyApi details, final Boolean nameRequired) {
+        this.details = details;
+        this.nameRequired = nameRequired;
+    }
+
+    public ProposedCompanyModel(final ProposedCompanyModel other) {
+        this.submissionId = other.getSubmissionId();
+        this.details = other.getDetails();
+        this.nameRequired = other.getNameRequired();
     }
 
     public String getSubmissionId() {
@@ -40,15 +45,31 @@ public class ProposedCompanyModel {
         this.submissionId = submissionId;
     }
 
-    @NotBlank(message = "{proposedCompany.error}")
+    public CompanyApi getDetails() {
+        return details;
+    }
+
+    public void setDetails(final CompanyApi details) {
+        this.details = details;
+    }
+
     public String getName() {
-        return name;
+        return Boolean.TRUE.equals(nameRequired) ? details.getCompanyName() : null;
     }
 
     public void setName(final String name) {
-        this.name = name;
+        details.setCompanyName(name);
     }
 
+    public String getNumber() {
+        return details.getCompanyNumber();
+    }
+    
+    public void setNumber(final String number) {
+        details.setCompanyNumber(number);
+    }
+
+    @NotNull
     public Boolean getNameRequired() {
         return nameRequired;
     }
@@ -67,13 +88,13 @@ public class ProposedCompanyModel {
         }
         final ProposedCompanyModel that = (ProposedCompanyModel) o;
         return Objects.equals(getSubmissionId(), that.getSubmissionId()) && Objects.equals(
-            getName(), that.getName()) && Objects.equals(getNameRequired(),
-            that.getNameRequired());
+            getNameRequired(), that.getNameRequired()) && Objects.equals(getDetails(),
+            that.getDetails());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getSubmissionId(), getName(), getNameRequired());
+        return Objects.hash(getSubmissionId(), getNameRequired(), getDetails());
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/efs/web/model/ProposedCompanyModel.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/model/ProposedCompanyModel.java
@@ -1,0 +1,84 @@
+package uk.gov.companieshouse.efs.web.model;
+
+import java.util.Objects;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.SessionScope;
+
+@Component
+@SessionScope
+public class ProposedCompanyModel {
+
+    private String submissionId;
+    private String name;
+    @NotNull(message = "{proposedCompany.blank.error}")
+    private Boolean nameRequired;
+
+    public ProposedCompanyModel() {
+        this.name = "";
+    }
+
+    /**
+     * Constructor sets the required value from the {@link ProposedCompanyModel}
+     *
+     * @param original the {@link ProposedCompanyModel}
+     */
+    public ProposedCompanyModel(final ProposedCompanyModel original) {
+        this.submissionId = original.getSubmissionId();
+        this.name = original.getName();
+        this.nameRequired = original.getNameRequired();
+    }
+
+    public String getSubmissionId() {
+        return submissionId;
+    }
+
+    public void setSubmissionId(final String submissionId) {
+        this.submissionId = submissionId;
+    }
+
+    @NotBlank(message = "{proposedCompany.error}")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public Boolean getNameRequired() {
+        return nameRequired;
+    }
+
+    public void setNameRequired(final Boolean nameRequired) {
+        this.nameRequired = nameRequired;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final ProposedCompanyModel that = (ProposedCompanyModel) o;
+        return Objects.equals(getSubmissionId(), that.getSubmissionId()) && Objects.equals(
+            getName(), that.getName()) && Objects.equals(getNameRequired(),
+            that.getNameRequired());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getSubmissionId(), getName(), getNameRequired());
+    }
+
+    @Override
+    public String toString() {
+        return ReflectionToStringBuilder.toString(this, ToStringStyle.SHORT_PREFIX_STYLE);
+    }
+
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -556,5 +556,7 @@ registrationsInfo.guidance.link=register a company (opens in new tab)
 
 #### Validation messages
 Pattern.paymentRequired.paymentReference=Enter a valid payment reference
+
+NotNull.proposedCompany.nameRequired=Select yes if you are uploading a document to register a Scottish limited partnership or a Scottish qualifying partnership
 proposedCompany.blank.error=Enter the proposed name of the firm or partnership
 proposedCompany.character.forbidden.error=The proposed name contains characters that are not permitted

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -538,6 +538,15 @@ resolutionsInfo.cannot=You cannot use this service to upload a resolution:
 resolutionsInfo.cannot.list1=to change the name of a company
 resolutionsInfo.cannot.list2=for company to community interest company (CIC) conversions and CIC to charitable company conversions
 
+#### Proposed name
+proposedCompany.title=Are you uploading a document to register a Scottish limited partnership or a Scottish qualifying partnership?
+proposedCompany.query.name.yes=Yes, I am uploading a document to register a Scottish limited partnership or a Scottish qualifying partnership
+proposedCompany.query.name.no=No, I am not uploading a document to register a Scottish limited partnership or a Scottish qualifying partnership
+proposedCompany.query.name.label=What is the proposed name of the firm or partnership?
+proposedCompany.query.name.hint=An examiner will check if the proposed name is acceptable. The name is still available for anyone to use until the registration document is accepted.
+
+
+
 #### Registrations info
 registrationsInfo.title=Registrations
 registrationsInfo.header=You can only upload documents to register an SLP or SQP
@@ -547,3 +556,5 @@ registrationsInfo.guidance.link=register a company (opens in new tab)
 
 #### Validation messages
 Pattern.paymentRequired.paymentReference=Enter a valid payment reference
+proposedCompany.blank.error=Enter the proposed name of the firm or partnership
+proposedCompany.character.forbidden.error=The proposed name contains characters that are not permitted

--- a/src/main/resources/templates/proposedCompany.html
+++ b/src/main/resources/templates/proposedCompany.html
@@ -20,13 +20,18 @@
                 <div th:replace="fragments/errorSummary :: errorSummary"></div>
                 <div id="content-wrapper" class="govuk-form-group" th:classappend="${#fields.hasErrors('*')} ? govuk-form-group--error : noerror">
                     <div class="govuk-form-group">
-                    <fieldset class="govuk-fieldset" aria-describedby="page-heading">
+                    <fieldset class="govuk-fieldset" aria-describedby="page-heading" data-required="data-required"
+                              th:attr="data-error=#{NotNull.proposedCompany.nameRequired}">
                         <!-- Display Question -->
 
                         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                             <h1 id="page-heading" class="govuk-fieldset__heading" th:text="#{proposedCompany.title}"></h1>
                         </legend>
                         <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+
+                        <span id="nameRequired-error" class="govuk-error-message"
+                              th:if="${#fields.hasErrors('nameRequired')}"
+                              th:each="e: ${#fields.errors('nameRequired')}" th:text="${e}"></span>
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input"
                                        id="name-required-conditional-1" name="nameRequired"
@@ -45,7 +50,7 @@
                                 <div class="govuk-form-group">
                                     <label class="govuk-label" for="proposed-name"
                                            th:text="#{proposedCompany.query.name.label}"></label>
-                                    <span id="proposed-name-error" class="govuk-error-message"
+                                    <span id="name-error" class="govuk-error-message"
                                           th:if="${#fields.hasErrors('name')}"
                                           th:each="e: ${#fields.errors('name')}"
                                           th:text="${e}"></span>
@@ -73,23 +78,13 @@
                                     </label>
                                 </div>
                             </div>
-   
-<!--
-                        <div class="govuk-form-group" th:classappend="${#fields.hasErrors('*')}
-                      ? 'govuk-form-group--error' : ''">
-                            <fieldset class="govuk-fieldset">
-                            <span id="name-error" class="govuk-error-message"
-                                      th:if="${#fields.hasErrors('nameRequired')}"
-                                      th:each="e: ${#fields.errors('nameRequired')}" th:text="${e}"></span>
-                                
-                            </fieldset>
-                        </div>
--->                    
                     </fieldset>
                     </div>
                 </div>
                 <div>
-                    <button data-prevent-double-click="true" id="submit-all" type="submit" class="govuk-button" name="action" value="submit" th:text="#{button.continue}">Continue</button>
+                    <button data-prevent-double-click="true" id="submit-all" type="submit" class="govuk-button"
+                            name="action" value="submit" th:text="#{button.continue}">Continue
+                    </button>
                 </div>
 
             </div>

--- a/src/main/resources/templates/proposedCompany.html
+++ b/src/main/resources/templates/proposedCompany.html
@@ -5,7 +5,7 @@
       layout:decorate="~{layouts/baseLayout}"
       lang="en">
 <head>
-    <title th:text="${#fields.hasErrors('${proposedCompany.*}')} ? #{error} + ' ' + #{proposedCompany.title}"></title>
+    <title th:text="${#fields.hasErrors('${proposedCompany.*}')} ? #{error} + ' ' + #{proposedCompany.title} : #{proposedCompany.title}"></title>
 </head>
 <body class="govuk-template__body" layout:fragment="content">
 
@@ -16,78 +16,78 @@
 
     <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
         <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-column-two-thirds-from-desktop">
                 <div th:replace="fragments/errorSummary :: errorSummary"></div>
-                <div id="content-wrapper" class="govuk-form-group" th:classappend="${#fields.hasErrors('name')} ? govuk-form-group--error : noerror">
-
+                <div id="content-wrapper" class="govuk-form-group" th:classappend="${#fields.hasErrors('*')} ? govuk-form-group--error : noerror">
+                    <div class="govuk-form-group">
                     <fieldset class="govuk-fieldset" aria-describedby="page-heading">
                         <!-- Display Question -->
+
                         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                             <h1 id="page-heading" class="govuk-fieldset__heading" th:text="#{proposedCompany.title}"></h1>
                         </legend>
-
-                        <div class="govuk-form-group"
-                             th:classappend="${#fields.hasErrors('nameRequired') || #fields.hasErrors('name')}
+                        <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input"
+                                       id="name-required-conditional-1" name="nameRequired"
+                                       type="radio" value="yes"
+                                       th:field="*{nameRequired}"
+                                       data-aria-controls="hidden-proposed-name"
+                                       data-target-text-field="hidden-proposed-name"
+                                       role="button">
+                                <label class="govuk-label govuk-radios__label"
+                                       for="name-required-conditional-1" th:text="|#{boolean.yes}|"
+                                       aria-label="Yes, I am uploading a document to register a Scottish limited partnership or a Scottish qualifying partnership"
+                                       th:attr="aria-label=#{proposedCompany.query.name.yes}">
+                                </label>
+                            </div>
+                            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="hidden-proposed-name">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label" for="proposed-name"
+                                           th:text="#{proposedCompany.query.name.label}"></label>
+                                    <span id="proposed-name-error" class="govuk-error-message"
+                                          th:if="${#fields.hasErrors('name')}"
+                                          th:each="e: ${#fields.errors('name')}"
+                                          th:text="${e}"></span>
+                                    <div class="govuk-hint" id="proposed-name-hint" th:text="#{proposedCompany.query.name.hint}">
+                                        An examiner will check if the proposed name is acceptable. The name is still available for anyone to use until the registration document is accepted.
+                                    </div>
+                                    <input class="govuk-input govuk-!-width-three-quarters"
+                                           id="proposed-name"
+                                           th:classappend="${#fields.hasErrors('name')}
+                                            ? 'govuk-input--error' : ''"
+                                           name="name" type="text"
+                                           th:field="*{name}">
+                                </div>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input show-text aria-toggle"
+                                       id="name-required-conditional-2" name="nameRequired"
+                                       type="radio" value="no"
+                                       th:field="*{nameRequired}"
+                                       data-target-text-field="hidden-proposed-name">
+                                    <label class="govuk-label govuk-radios__label"
+                                           for="name-required-conditional-2" th:text="|#{boolean.no}|"
+                                           aria-label="No, I am not uploading a document to register a Scottish limited partnership or a Scottish qualifying partnership"
+                                           th:attr="aria-label=#{proposedCompany.query.name.no}">
+                                    </label>
+                                </div>
+                            </div>
+   
+<!--
+                        <div class="govuk-form-group" th:classappend="${#fields.hasErrors('*')}
                       ? 'govuk-form-group--error' : ''">
                             <fieldset class="govuk-fieldset">
-                                <span id="name-error" class="govuk-error-message"
-                                      th:if="${#fields.hasErrors('name')}"
-                                      th:each="e: ${#fields.errors('name')}" th:text="${e}"></span>
-                                <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
-                                    <div class="govuk-radios__item">
-                                        <input class="govuk-radios__input"
-                                               id="name-required" name="nameRequired"
-                                               type="radio" value="yes"
-                                               th:field="*{nameRequired}"
-                                               data-aria-controls="proposed-name-conditional"
-                                               data-target-text-field="proposed-name-conditional"
-                                               role="button">
-                                        <label class="govuk-label govuk-radios__label"
-                                               for="proposed-name-conditional" th:text="|#{boolean.yes}|"
-                                               aria-label="Yes, I am uploading a document to register a Scottish limited partnership or a Scottish qualifying partnership"
-                                               th:attr="aria-label=#{proposedCompany.query.name.yes}">
-                                        </label>
-                                    </div>
-                                    <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
-                                         id="proposed-name-conditional">
-                                        <div class="govuk-form-group">
-                                            <label class="govuk-label" for="proposed-name"
-                                                   th:text="#{proposedCompany.query.name.label}"></label>
-                                            <span id="proposed-name-error" class="govuk-error-message"
-                                                  th:if="${#fields.hasErrors('name')}"
-                                                  th:each="e: ${#fields.errors('name')}"
-                                                  th:text="${e}"></span>
-                                            <div class="govuk-hint govuk-radios__hint" id="proposed-name-hint" th:text="#{proposedCompany.query.name.hint}">
-                                                An examiner will check if the proposed name is acceptable. The name is still available for anyone to use until the registration document is accepted.
-                                            </div>
-                                            <input class="govuk-input govuk-!-width-three-quarters"
-                                                   id="proposed-name"
-                                                   th:classappend="${#fields.hasErrors('name')}
-                                            ? 'govuk-input--error' : ''"
-                                                   name="proposed-name" type="text"
-                                                   th:field="*{name}">
-                                        </div>
-                                    </div>
-                                    <div class="govuk-radios__item">
-                                        <input class="govuk-radios__input"
-                                               id="proposed-name-conditional-1" name="proposed-name"
-                                               type="radio" value="no"
-                                               th:field="*{nameRequired}"
-                                               data-aria-controls="proposed-name-conditional-1"
-                                               data-target-text-field="conditional-proposed-name-conditional-1">
-                                        <label class="govuk-label govuk-radios__label"
-                                               for="proposed-name-conditional-1" th:text="|#{boolean.no}|"
-                                               aria-label="No, I am not uploading a document to register a Scottish limited partnership or a Scottish qualifying partnership"
-                                               th:attr="aria-label=#{proposedCompany.query.name.no}">
-                                        </label>
-                                    </div>
-                                </div>
+                            <span id="name-error" class="govuk-error-message"
+                                      th:if="${#fields.hasErrors('nameRequired')}"
+                                      th:each="e: ${#fields.errors('nameRequired')}" th:text="${e}"></span>
                                 
                             </fieldset>
                         </div>
+-->                    
                     </fieldset>
+                    </div>
                 </div>
-
                 <div>
                     <button data-prevent-double-click="true" id="submit-all" type="submit" class="govuk-button" name="action" value="submit" th:text="#{button.continue}">Continue</button>
                 </div>

--- a/src/main/resources/templates/proposedCompany.html
+++ b/src/main/resources/templates/proposedCompany.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/baseLayout}"
+      lang="en">
+<head>
+    <title th:text="${#fields.hasErrors('${proposedCompany.*}')} ? #{error} + ' ' + #{proposedCompany.title}"></title>
+</head>
+<body class="govuk-template__body" layout:fragment="content">
+
+<form th:action="@{/efs-submission/{id}/company/noCompany/proposed-company(id=*{submissionId})}"
+      th:object="${proposedCompany}" method="post">
+
+    <a class="govuk-back-link" th:href="@{/efs-submission/start}" th:text="#{link.back}"></a>
+
+    <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <div th:replace="fragments/errorSummary :: errorSummary"></div>
+                <div id="content-wrapper" class="govuk-form-group" th:classappend="${#fields.hasErrors('name')} ? govuk-form-group--error : noerror">
+
+                    <fieldset class="govuk-fieldset" aria-describedby="page-heading">
+                        <!-- Display Question -->
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 id="page-heading" class="govuk-fieldset__heading" th:text="#{proposedCompany.title}"></h1>
+                        </legend>
+
+                        <div class="govuk-form-group"
+                             th:classappend="${#fields.hasErrors('nameRequired') || #fields.hasErrors('name')}
+                      ? 'govuk-form-group--error' : ''">
+                            <fieldset class="govuk-fieldset">
+                                <span id="name-error" class="govuk-error-message"
+                                      th:if="${#fields.hasErrors('name')}"
+                                      th:each="e: ${#fields.errors('name')}" th:text="${e}"></span>
+                                <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input"
+                                               id="name-required" name="nameRequired"
+                                               type="radio" value="yes"
+                                               th:field="*{nameRequired}"
+                                               data-aria-controls="proposed-name-conditional"
+                                               data-target-text-field="proposed-name-conditional"
+                                               role="button">
+                                        <label class="govuk-label govuk-radios__label"
+                                               for="proposed-name-conditional" th:text="|#{boolean.yes}|"
+                                               aria-label="Yes, I am uploading a document to register a Scottish limited partnership or a Scottish qualifying partnership"
+                                               th:attr="aria-label=#{proposedCompany.query.name.yes}">
+                                        </label>
+                                    </div>
+                                    <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
+                                         id="proposed-name-conditional">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label" for="proposed-name"
+                                                   th:text="#{proposedCompany.query.name.label}"></label>
+                                            <span id="proposed-name-error" class="govuk-error-message"
+                                                  th:if="${#fields.hasErrors('name')}"
+                                                  th:each="e: ${#fields.errors('name')}"
+                                                  th:text="${e}"></span>
+                                            <div class="govuk-hint govuk-radios__hint" id="proposed-name-hint" th:text="#{proposedCompany.query.name.hint}">
+                                                An examiner will check if the proposed name is acceptable. The name is still available for anyone to use until the registration document is accepted.
+                                            </div>
+                                            <input class="govuk-input govuk-!-width-three-quarters"
+                                                   id="proposed-name"
+                                                   th:classappend="${#fields.hasErrors('name')}
+                                            ? 'govuk-input--error' : ''"
+                                                   name="proposed-name" type="text"
+                                                   th:field="*{name}">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input"
+                                               id="proposed-name-conditional-1" name="proposed-name"
+                                               type="radio" value="no"
+                                               th:field="*{nameRequired}"
+                                               data-aria-controls="proposed-name-conditional-1"
+                                               data-target-text-field="conditional-proposed-name-conditional-1">
+                                        <label class="govuk-label govuk-radios__label"
+                                               for="proposed-name-conditional-1" th:text="|#{boolean.no}|"
+                                               aria-label="No, I am not uploading a document to register a Scottish limited partnership or a Scottish qualifying partnership"
+                                               th:attr="aria-label=#{proposedCompany.query.name.no}">
+                                        </label>
+                                    </div>
+                                </div>
+                                
+                            </fieldset>
+                        </div>
+                    </fieldset>
+                </div>
+
+                <div>
+                    <button data-prevent-double-click="true" id="submit-all" type="submit" class="govuk-button" name="action" value="submit" th:text="#{button.continue}">Continue</button>
+                </div>
+
+            </div>
+        </div>
+
+    </main>
+</form>
+</body>
+</html>

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/ProposedCompanyControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/ProposedCompanyControllerImplTest.java
@@ -1,0 +1,135 @@
+package uk.gov.companieshouse.efs.web.controller;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.companieshouse.efs.web.model.ProposedCompanyModel;
+
+@ExtendWith(MockitoExtension.class)
+class ProposedCompanyControllerImplTest extends BaseControllerImplTest {
+    private ProposedCompanyController testController;
+
+    @Mock
+    private ProposedCompanyModel proposedCompanyAttribute;
+
+    @BeforeEach
+    void setUp() {
+        setUpHeaders();
+        testController = new ProposedCompanyControllerImpl(logger, sessionService, apiClientService,
+            proposedCompanyAttribute);
+        ((ProposedCompanyControllerImpl) testController).setChsUrl(CHS_URL);
+        // turn on feature flag
+        ReflectionTestUtils.setField(testController, "registrationsEnabled", true);
+    }
+
+    @Test
+    void getProposedCompanyAttribute() {
+        assertThat(((ProposedCompanyControllerImpl) testController).getProposedCompanyAttribute(),
+            is(sameInstance(proposedCompanyAttribute)));
+    }
+
+    @Test
+    void getViewName() {
+        MatcherAssert.assertThat(((ProposedCompanyControllerImpl) testController).getViewName(),
+            is(ViewConstants.PROPOSED_COMPANY.asView()));
+    }
+
+    @Test
+    void prepareWhenFeatureDisabled() {
+        ReflectionTestUtils.setField(testController, "registrationsEnabled", false);
+
+        final String result =
+            testController.prepare(SUBMISSION_ID, proposedCompanyAttribute, model, request);
+
+        assertThat(result, is(ViewConstants.MISSING.asView()));
+    }
+
+    @Test
+    void prepareWhenFeatureEnabled() {
+        when(proposedCompanyAttribute.getName()).thenReturn(COMPANY_NAME);
+        final String result =
+            testController.prepare(SUBMISSION_ID, proposedCompanyAttribute, model, request);
+
+        verify(proposedCompanyAttribute).setSubmissionId(SUBMISSION_ID);
+        verify(proposedCompanyAttribute).setNumber(
+            ProposedCompanyControllerImpl.TEMP_COMPANY_NUMBER);
+        verify(proposedCompanyAttribute).setName(COMPANY_NAME);
+        assertThat(result, is(ViewConstants.PROPOSED_COMPANY.asView()));
+    }
+
+    @Test
+    void processWhenFeatureDisabled() {
+        ReflectionTestUtils.setField(testController, "registrationsEnabled", false);
+
+        final String result =
+            testController.process(SUBMISSION_ID, proposedCompanyAttribute, bindingResult, model,
+                request, session);
+
+        assertThat(result, is(ViewConstants.MISSING.asView()));
+    }
+
+    @Test
+    void processWhenFeatureEnabledAndBindingErrors() {
+        when(bindingResult.hasErrors()).thenReturn(true);
+
+        final String result =
+            testController.process(SUBMISSION_ID, proposedCompanyAttribute, bindingResult, model,
+                request, session);
+
+        verify(model).addAttribute(TEMPLATE_NAME, ViewConstants.PROPOSED_COMPANY.asView());
+        assertThat(result, is(ViewConstants.PROPOSED_COMPANY.asView()));
+    }
+
+    @Test
+    void processWhenFeatureEnabledAndNameRequiredNull() {
+        when(bindingResult.hasErrors()).thenReturn(true);
+
+        final String result =
+            testController.process(SUBMISSION_ID, proposedCompanyAttribute, bindingResult, model,
+                request, session);
+
+        verify(model).addAttribute(TEMPLATE_NAME, ViewConstants.PROPOSED_COMPANY.asView());
+        assertThat(result, is(ViewConstants.PROPOSED_COMPANY.asView()));
+    }
+
+    @Test
+    void processWhenFeatureEnabledAndNameRequiredFalse() {
+        when(proposedCompanyAttribute.getNameRequired()).thenReturn(Boolean.FALSE);
+        when(proposedCompanyAttribute.getNumber()).thenReturn(
+            ProposedCompanyControllerImpl.TEMP_COMPANY_NUMBER);
+
+        final String result =
+            testController.process(SUBMISSION_ID, proposedCompanyAttribute, bindingResult, model,
+                request, session);
+
+        verify(proposedCompanyAttribute).setName(null);
+        assertThat(result, is(ViewConstants.REGISTRATIONS_INFO.asRedirectUri(CHS_URL, SUBMISSION_ID,
+            ProposedCompanyControllerImpl.TEMP_COMPANY_NUMBER)));
+    }
+
+    @Test
+    void processWhenFeatureEnabledAndNameRequiredTrue() {
+        when(proposedCompanyAttribute.getNameRequired()).thenReturn(Boolean.TRUE);
+        when(proposedCompanyAttribute.getNumber()).thenReturn(
+            ProposedCompanyControllerImpl.TEMP_COMPANY_NUMBER);
+
+        final String result =
+            testController.process(SUBMISSION_ID, proposedCompanyAttribute, bindingResult, model,
+                request, session);
+
+
+        verify(proposedCompanyAttribute).setName("");
+        assertThat(result, is(ViewConstants.CATEGORY_SELECTION.asRedirectUri(CHS_URL, SUBMISSION_ID,
+            ProposedCompanyControllerImpl.TEMP_COMPANY_NUMBER)));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/ResolutionsInfoControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/ResolutionsInfoControllerImplTest.java
@@ -4,20 +4,14 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
 import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.api.model.efs.categorytemplates.CategoryTemplateApi;
 import uk.gov.companieshouse.api.model.efs.formtemplates.FormTemplateApi;
-import uk.gov.companieshouse.api.model.efs.formtemplates.FormTemplateListApi;
-import uk.gov.companieshouse.api.model.efs.submissions.FormTypeApi;
 import uk.gov.companieshouse.api.model.efs.submissions.SubmissionApi;
-import uk.gov.companieshouse.api.model.efs.submissions.SubmissionResponseApi;
 import uk.gov.companieshouse.api.model.efs.submissions.SubmissionStatus;
 
 @ExtendWith(MockitoExtension.class)


### PR DESCRIPTION
Activated by feature flag EFS_REGISTRATIONS_ENABLED

- add "Are you uploading a doc to register a SLP/SQP" screen
- link to previous screen ("no number" link on company lookup service page) BI-7388
- link "No" response to end page BI-7502
- add validation for question not answered