### PR TITLE
Fix payment failed email resending on confirmation page refresh

### DIFF
--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/ConfirmationControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/ConfirmationControllerImpl.java
@@ -62,8 +62,7 @@ public class ConfirmationControllerImpl extends BaseControllerImpl implements Co
         final SubmissionApi submission = fetchSubmission(id);
         final SubmissionStatus submissionStatus = submission.getStatus();
         final EnumSet<SubmissionStatus> allowedStatuses =
-            EnumSet.of(SubmissionStatus.OPEN, SubmissionStatus.PAYMENT_RECEIVED,
-                SubmissionStatus.PAYMENT_FAILED);
+            EnumSet.of(SubmissionStatus.OPEN, SubmissionStatus.PAYMENT_RECEIVED);
 
         if (!allowedStatuses.contains(submissionStatus)) {
             return ViewConstants.GONE.asView();

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/ConfirmationControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/ConfirmationControllerImplTest.java
@@ -93,4 +93,16 @@ class ConfirmationControllerImplTest extends BaseControllerImplTest {
         assertThat(result, is(ViewConstants.GONE.asView()));
     }
 
+    @Test
+    void getConfirmationWhenPaymentFailedThenEmailNotResent                                                                                                                                                () {
+        final SubmissionApi submission = createSubmission(SubmissionStatus.PAYMENT_FAILED);
+        when(apiClientService.fetchSubmission(SUBMISSION_ID)).thenReturn(
+            new ApiResponse<>(200, headers, submission));
+
+        final String result = testController.getConfirmation(SUBMISSION_ID, COMPANY_NUMBER, companyDetail,
+                model, request, session, sessionStatus);
+
+        assertThat(result, is(ViewConstants.GONE.asView()));
+    }
+
 }


### PR DESCRIPTION
- remove PAYMENT_FAILED from allowed statuses for confirmation page

Resolves:
BI-7733