### PR TITLE
Added sub heading for root category selection screen

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -322,6 +322,7 @@ removeDocument.button.continue=Continue
 
 # Forms
 documentSelection.title=What type of document are you uploading?
+documentSelection.subtitle=Document category
 documentSelection.docType=Select a document
 documentSelection.hint=Choose from the list below.
 documentSelection.formType=Form type:

--- a/src/main/resources/templates/categorySelection.html
+++ b/src/main/resources/templates/categorySelection.html
@@ -24,8 +24,8 @@
                         <fieldset class="govuk-fieldset" data-required="data-required"
                                   th:attr="data-error=#{NotBlankCategoryTemplate.categoryTemplate.details}">
                             <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-                                <span id="category-name" class="govuk-caption-xl"
-                                      th:text="*{parentCategory.categoryName}"></span>
+                                <span id="category-name" class="govuk-caption-l"
+                                      th:text="*{parentCategory.categoryName} != '' ? *{parentCategory.categoryName} : #{documentSelection.subtitle}"></span>
                                 <h1 class="govuk-fieldset__heading"
                                     th:text="#{categorySelection.catType}"></h1>
                             </legend>


### PR DESCRIPTION
Added "Document category" sub heading to the top of the root category selection screen.

Reused existing sub heading which was being used to show the parent category if there was one. 
Changed class of this heading from "govuk-caption-xl" to "govuk-caption-l". This matches the prototype for the root category and categories with parents such as Insolvency 

[BI-6496](https://companieshouse.atlassian.net/browse/BI-6496)