### PR TITLE
Extend dynamic guidance to category / document selection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
         <java.version>1.8</java.version>
         <java-session-handler.version>2.2.0</java-session-handler.version>
-        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.70</private-api-sdk-java.version>
         <sdk-manager-java.version>1.5.10</sdk-manager-java.version>
         <rest-service-common-library.version>0.0.3</rest-service-common-library.version>
         <environment-reader-library.version>1.3.2</environment-reader-library.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
         <java.version>1.8</java.version>
         <java-session-handler.version>2.2.0</java-session-handler.version>
-        <private-api-sdk-java.version>2.0.68</private-api-sdk-java.version>
+        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
         <sdk-manager-java.version>1.5.10</sdk-manager-java.version>
         <rest-service-common-library.version>0.0.3</rest-service-common-library.version>
         <environment-reader-library.version>1.3.2</environment-reader-library.version>
@@ -308,6 +308,12 @@
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <version>2.6.0</version>
+
+                <configuration>
+                    <from>
+                        <image>openjdk:11-jre-slim</image>
+                    </from>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/uk/gov/companieshouse/efs/web/categorytemplates/controller/CategoryTemplateControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/categorytemplates/controller/CategoryTemplateControllerImpl.java
@@ -99,13 +99,14 @@ public class CategoryTemplateControllerImpl extends BaseControllerImpl implement
         categorySequenceList = Optional.ofNullable(categorySequenceList)
                 .orElse(new ArrayList<>());
 
+        // TODO: we should probably handle API response failure
         final Boolean isEmailAllowed = apiClientService.isOnAllowList(
                 submissionApi.getPresenter().getEmail()).getData();
         final boolean sequenceHasInsolvency =
                 categorySequenceList.contains(
                         INSOLVENCY.getValue());
 
-        // TODO: we should probably handle failure
+        // TODO: we should probably handle API response failure
         final CategoryTemplateListApi allCategoryTemplates =
                 categoryTemplateService.getCategoryTemplates().getData();
 

--- a/src/main/java/uk/gov/companieshouse/efs/web/categorytemplates/model/CategoryTemplateModel.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/categorytemplates/model/CategoryTemplateModel.java
@@ -25,7 +25,7 @@ import uk.gov.companieshouse.efs.web.categorytemplates.validator.NotBlankCategor
 @SessionScope
 public class CategoryTemplateModel {
     public static final String ROOT_CATEGORY_ID = "";
-    public static final CategoryTemplateApi ROOT_CATEGORY = new CategoryTemplateApi(ROOT_CATEGORY_ID, "", null, null);
+    public static final CategoryTemplateApi ROOT_CATEGORY = new CategoryTemplateApi(ROOT_CATEGORY_ID, "", null, null, null);
 
     private String submissionId;
     private String companyNumber;
@@ -156,7 +156,8 @@ public class CategoryTemplateModel {
      * @return category type that is the parent category of the view
      */
     public CategoryTemplateApi getParentCategory() {
-        return Optional.ofNullable(categoryStack.peekLast()).orElse(new CategoryTemplateApi(ROOT_CATEGORY));
+        return Optional.ofNullable(categoryStack.peekLast())
+                .orElse(new CategoryTemplateApi(ROOT_CATEGORY));
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/efs/web/formtemplates/controller/FormTemplateControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/formtemplates/controller/FormTemplateControllerImpl.java
@@ -5,7 +5,9 @@ import static uk.gov.companieshouse.efs.web.categorytemplates.controller.Categor
 import static uk.gov.companieshouse.efs.web.categorytemplates.controller.CategoryTypeConstants.RESOLUTIONS;
 import static uk.gov.companieshouse.efs.web.formtemplates.controller.FormTemplateControllerImpl.ATTRIBUTE_NAME;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.SessionAttribute;
 import org.springframework.web.bind.annotation.SessionAttributes;
 import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.api.model.efs.categorytemplates.CategoryTemplateApi;
 import uk.gov.companieshouse.api.model.efs.formtemplates.FormTemplateApi;
 import uk.gov.companieshouse.api.model.efs.formtemplates.FormTemplateListApi;
 import uk.gov.companieshouse.api.model.efs.submissions.FormTypeApi;
@@ -127,7 +130,20 @@ public class FormTemplateControllerImpl extends BaseControllerImpl implements Fo
         model.addAttribute("isScottishCompany", isScottishCompany(companyNumber));
         addTrackingAttributeToModel(model);
 
+        addGuidanceFragmentIdsToModel(categoryTemplateAttribute, model);
+
+
         return ViewConstants.DOCUMENT_SELECTION.asView();
+    }
+
+    private void addGuidanceFragmentIdsToModel(CategoryTemplateModel categoryTemplateAttribute, Model model) {
+        CategoryTemplateApi currentCategory = categoryTemplateAttribute.getParentCategory();
+        List<Integer> guidanceTextList = currentCategory.getGuidanceTextList();
+
+        Map<String, Object> info = new HashMap<>();
+        info.put("guidance_text_ids", guidanceTextList);
+        logger.info("Adding guidance fragment ID's to category template", info);
+        model.addAttribute("guidance_fragment_ids", guidanceTextList);
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/efs/web/model/ProposedCompanyModel.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/model/ProposedCompanyModel.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.efs.web.model;
 
 import java.util.Objects;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;

--- a/src/main/resources/templates/categorySelection.html
+++ b/src/main/resources/templates/categorySelection.html
@@ -28,6 +28,12 @@
                                       th:text="*{parentCategory.categoryName} != '' ? *{parentCategory.categoryName} : #{documentSelection.subtitle}"></span>
                                 <h1 class="govuk-fieldset__heading"
                                     th:text="#{categorySelection.catType}"></h1>
+
+                                <!-- Guidance text -->
+                                <div th:each="textId : ${guidance_fragment_ids}">
+                                    <div th:replace="__${'fragments/categorySelection/guidance :: guidance' + textId}__"></div>
+                                </div>
+
                             </legend>
                             <div class="govuk-form-group" th:classappend="${#fields.hasErrors('*')}
                                 ? 'govuk-form-group--error' : ''">

--- a/src/main/resources/templates/documentSelection.html
+++ b/src/main/resources/templates/documentSelection.html
@@ -47,6 +47,10 @@
                                 </div>
                             </fieldset>
                         <div>
+                            <!-- Guidance text -->
+                            <div th:each="textId : ${guidance_fragment_ids}">
+                                <div th:replace="__${'fragments/documentSelection/guidance :: guidance' + textId}__"></div>
+                            </div>
                             <button data-prevent-double-click="true" id="submit-all" type="submit" class="govuk-button"
                                     name="action" value="submit"
                                     th:text="#{button.continue}"></button>

--- a/src/test/java/uk/gov/companieshouse/efs/web/categorytemplates/controller/CategoryTemplateControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/categorytemplates/controller/CategoryTemplateControllerImplTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.efs.web.categorytemplates.controller.CategoryTypeConstants.ROOT;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -42,23 +43,23 @@ public class CategoryTemplateControllerImplTest extends BaseControllerImplTest {
      *     CAT1_SUB_LEVEL2   CAT2_SUB_LEVEL2          INS_SUB_LEVEL2
      */
     public static final CategoryTemplateApi ROOT_LEVEL = new CategoryTemplateApi("",
-            "Dummy ROOT level category", "", null);
+            "Dummy ROOT level category", "", null, null);
     public static final CategoryTemplateApi CAT_TOP_LEVEL = new CategoryTemplateApi("CAT_TOP_LEVEL",
-            "Dummy top level category", "", null);
+            "Dummy top level category", "", null, null);
     public static final CategoryTemplateApi INSOLVENCY = new CategoryTemplateApi("INS",
-            "INSOLVENCY", "", null);
+            "INSOLVENCY", "", null, null);
     public static final CategoryTemplateApi INS_SUB_LEVEL1 = new CategoryTemplateApi(
-            "INS_SUB_LEVEL1", "Dummy insolvency category 1, subcategory level 1", "INS", null);
+            "INS_SUB_LEVEL1", "Dummy insolvency category 1, subcategory level 1", "INS", null, null);
     public static final CategoryTemplateApi INS_SUB_LEVEL2 = new CategoryTemplateApi(
-            "INS_SUB_LEVEL2", "Dummy insolvency category 1, subcategory level 2", "INS_SUB_LEVEL1", null);
+            "INS_SUB_LEVEL2", "Dummy insolvency category 1, subcategory level 2", "INS_SUB_LEVEL1", null, null);
     public static final CategoryTemplateApi CAT1_SUB_LEVEL1 = new CategoryTemplateApi(
-            "CAT1_SUB_LEVEL1", "Dummy category 1, subcategory level 1", "CAT_TOP_LEVEL", null);
+            "CAT1_SUB_LEVEL1", "Dummy category 1, subcategory level 1", "CAT_TOP_LEVEL", null, null);
     public static final CategoryTemplateApi CAT2_SUB_LEVEL1 = new CategoryTemplateApi(
-            "CAT2_SUB_LEVEL1", "Dummy category 2, subcategory level 1", "CAT_TOP_LEVEL", null);
+            "CAT2_SUB_LEVEL1", "Dummy category 2, subcategory level 1", "CAT_TOP_LEVEL", null, null);
     public static final CategoryTemplateApi CAT1_SUB_LEVEL2 = new CategoryTemplateApi(
-            "CAT1_SUB_LEVEL2", "Dummy category1, subcategory level 2", "CAT1_SUB_LEVEL1", null);
+            "CAT1_SUB_LEVEL2", "Dummy category1, subcategory level 2", "CAT1_SUB_LEVEL1", null, null);
     public static final CategoryTemplateApi CAT2_SUB_LEVEL2 = new CategoryTemplateApi(
-            "CAT2_SUB_LEVEL2", "Dummy category 2, subcategory level 2", "CAT1_SUB_LEVEL1", null);
+            "CAT2_SUB_LEVEL2", "Dummy category 2, subcategory level 2", "CAT1_SUB_LEVEL1", null, null);
     public static final List<CategoryTemplateApi> ALL_CATEGORIES = Arrays.asList(CAT_TOP_LEVEL,
             INSOLVENCY, CAT1_SUB_LEVEL1, CAT2_SUB_LEVEL1, CAT1_SUB_LEVEL2, CAT2_SUB_LEVEL2);
 
@@ -110,7 +111,7 @@ public class CategoryTemplateControllerImplTest extends BaseControllerImplTest {
                 Arrays.asList(CAT_TOP_LEVEL, INSOLVENCY));
 
         expectInteractionsForGet(submission, true, expectedCategoryList,
-                CategoryTemplateModel.ROOT_CATEGORY_ID, null);
+                CategoryTemplateModel.ROOT_CATEGORY_ID, null, categoryTemplateAttribute);
 
         final String result = testController.categoryTemplate(SUBMISSION_ID, COMPANY_NUMBER, null,
                 categoryTemplateAttribute, model, servletRequest);
@@ -126,7 +127,7 @@ public class CategoryTemplateControllerImplTest extends BaseControllerImplTest {
                 Arrays.asList(CAT_TOP_LEVEL, INSOLVENCY));
 
         expectInteractionsForGet(submission, true, expectedCategoryList,
-                INSOLVENCY.getCategoryType(), null);
+                INSOLVENCY.getCategoryType(), null, categoryTemplateAttribute);
 
         final String result = testController.categoryTemplate(SUBMISSION_ID, COMPANY_NUMBER,
                 Collections.singletonList(INSOLVENCY.getCategoryType()), categoryTemplateAttribute,
@@ -185,7 +186,7 @@ public class CategoryTemplateControllerImplTest extends BaseControllerImplTest {
                 Arrays.asList(CAT_TOP_LEVEL, INSOLVENCY));
 
         expectInteractionsForGet(submission, true, expectedCategoryList,
-                CategoryTemplateModel.ROOT_CATEGORY_ID, null);
+                CategoryTemplateModel.ROOT_CATEGORY_ID, null, categoryTemplateAttribute);
 
         final List<String> categorySequenceList = Collections.emptyList();
         final String result = testController.categoryTemplate(SUBMISSION_ID, COMPANY_NUMBER,
@@ -202,7 +203,7 @@ public class CategoryTemplateControllerImplTest extends BaseControllerImplTest {
                 Collections.singletonList(CAT_TOP_LEVEL));
 
         expectInteractionsForGet(submission, false, expectedCategoryList,
-                CategoryTemplateModel.ROOT_CATEGORY_ID, null);
+                CategoryTemplateModel.ROOT_CATEGORY_ID, null, categoryTemplateAttribute);
         when(apiClientService.isOnAllowList(anyString())).thenReturn(
                 new ApiResponse<>(200, getHeaders(), Boolean.FALSE));
 
@@ -221,7 +222,7 @@ public class CategoryTemplateControllerImplTest extends BaseControllerImplTest {
                 Collections.singletonList(CAT1_SUB_LEVEL1));
 
         expectInteractionsForGet(submission, true, categoryList, CAT_TOP_LEVEL.getCategoryType(),
-                CAT_TOP_LEVEL);
+                CAT_TOP_LEVEL, categoryTemplateAttribute);
 
         final String result = testController.categoryTemplate(SUBMISSION_ID, COMPANY_NUMBER,
                 Collections.singletonList(CAT_TOP_LEVEL.getCategoryType()),
@@ -238,7 +239,7 @@ public class CategoryTemplateControllerImplTest extends BaseControllerImplTest {
                 Collections.singletonList(CAT1_SUB_LEVEL1));
 
         expectInteractionsForGet(submission, false, categoryList, CAT_TOP_LEVEL.getCategoryType(),
-                CAT_TOP_LEVEL);
+                CAT_TOP_LEVEL, categoryTemplateAttribute);
 
         final String result = testController.categoryTemplate(SUBMISSION_ID, COMPANY_NUMBER,
                 Collections.singletonList(CAT_TOP_LEVEL.getCategoryType()),
@@ -255,7 +256,7 @@ public class CategoryTemplateControllerImplTest extends BaseControllerImplTest {
                 Arrays.asList(CAT1_SUB_LEVEL2, CAT2_SUB_LEVEL2));
 
         expectInteractionsForGet(submission, true, categoryList, CAT1_SUB_LEVEL1.getCategoryType(),
-                CAT1_SUB_LEVEL1);
+                CAT1_SUB_LEVEL1, categoryTemplateAttribute);
 
         final String result = testController.categoryTemplate(SUBMISSION_ID, COMPANY_NUMBER,
                 Arrays.asList(CAT_TOP_LEVEL.getCategoryType(), CAT1_SUB_LEVEL1.getCategoryType()),
@@ -346,11 +347,11 @@ public class CategoryTemplateControllerImplTest extends BaseControllerImplTest {
     }
 
     private void expectInteractionsForGet(final SubmissionApi submission, final Boolean isAllowed,
-            final CategoryTemplateListApi categoryList, final String leafCategoryId,
-            final CategoryTemplateApi removedCategoryId) {
+                                          final CategoryTemplateListApi categoryList, final String leafCategoryId,
+                                          final CategoryTemplateApi removedCategoryId, CategoryTemplateModel categoryTemplateAttribute) {
         when(apiClientService.getSubmission(SUBMISSION_ID)).thenReturn(
                 getSubmissionOkResponse(submission));
-        when(categoryTemplateAttribute.rewindCategoryStack(leafCategoryId)).thenReturn(
+        when(this.categoryTemplateAttribute.rewindCategoryStack(leafCategoryId)).thenReturn(
                 removedCategoryId);
         when(categoryTemplateService.getCategoryTemplates()).thenReturn(
                 new ApiResponse<>(200, getHeaders(), new CategoryTemplateListApi(ALL_CATEGORIES)));
@@ -358,6 +359,9 @@ public class CategoryTemplateControllerImplTest extends BaseControllerImplTest {
                 new ApiResponse<>(200, getHeaders(), categoryList));
         when(apiClientService.isOnAllowList(anyString())).thenReturn(
                 new ApiResponse<>(200, getHeaders(), isAllowed));
+        when(categoryTemplateAttribute.getParentCategory()).thenReturn(new CategoryTemplateApi());
+        when(categoryTemplateService.getCategoryTemplate(ROOT.getValue())).thenReturn(
+                new ApiResponse<>(200, getHeaders(), new CategoryTemplateApi()));
     }
 
     private void expectInteractionsForPost(final CategoryTemplateApi details,

--- a/src/test/java/uk/gov/companieshouse/efs/web/categorytemplates/model/CategoryTemplateModelTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/categorytemplates/model/CategoryTemplateModelTest.java
@@ -18,7 +18,7 @@ class CategoryTemplateModelTest {
 
     @BeforeEach
     void setUp() {
-        categoryTemplate = new CategoryTemplateApi("CC01", "CategoryC01", "INS", "CC01");
+        categoryTemplate = new CategoryTemplateApi("CC01", "CategoryC01", "INS", "CC01", null);
         testCategoryTemplate = new CategoryTemplateModel(categoryTemplate);
     }
 
@@ -26,12 +26,12 @@ class CategoryTemplateModelTest {
     void defaultConstructor() {
         testCategoryTemplate = new CategoryTemplateModel();
 
-        assertThat(testCategoryTemplate.getDetails(), is(new CategoryTemplateApi("", "", null, null)));
+        assertThat(testCategoryTemplate.getDetails(), is(new CategoryTemplateApi("", "", null, null, null)));
     }
 
     @Test
     void setGetDetails() {
-        CategoryTemplateApi expected = new CategoryTemplateApi("CC01", "CategoryC01", "INS", "CC01");
+        CategoryTemplateApi expected = new CategoryTemplateApi("CC01", "CategoryC01", "INS", "CC01", null);
 
         testCategoryTemplate.setDetails(expected);
 

--- a/src/test/java/uk/gov/companieshouse/efs/web/categorytemplates/service/api/impl/CategoryTemplateServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/categorytemplates/service/api/impl/CategoryTemplateServiceImplTest.java
@@ -157,7 +157,7 @@ class CategoryTemplateServiceImplTest {
     @Test
     void getTopLevelCategoryGivenResolutionsCategory() throws ApiErrorResponseException, URIValidationException {
         final CategoryTemplateApi category = new CategoryTemplateApi("RESOLUTIONS",
-                "RESOLUTIONS", "", null, null);;
+                "RESOLUTIONS", "", null, null);
 
         expectGetCategoryTemplate();
         when(categoryTemplateGet.execute()).thenReturn(buildApiResponseOK(category));

--- a/src/test/java/uk/gov/companieshouse/efs/web/categorytemplates/service/api/impl/CategoryTemplateServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/categorytemplates/service/api/impl/CategoryTemplateServiceImplTest.java
@@ -157,7 +157,7 @@ class CategoryTemplateServiceImplTest {
     @Test
     void getTopLevelCategoryGivenResolutionsCategory() throws ApiErrorResponseException, URIValidationException {
         final CategoryTemplateApi category = new CategoryTemplateApi("RESOLUTIONS",
-                "RESOLUTIONS", "", null);;
+                "RESOLUTIONS", "", null, null);;
 
         expectGetCategoryTemplate();
         when(categoryTemplateGet.execute()).thenReturn(buildApiResponseOK(category));

--- a/src/test/java/uk/gov/companieshouse/efs/web/categorytemplates/validator/NotBlankCategoryTemplateValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/categorytemplates/validator/NotBlankCategoryTemplateValidatorTest.java
@@ -47,7 +47,7 @@ class NotBlankCategoryTemplateValidatorTest {
     void isNotValidWhenValuesBlank() {
 
         boolean valid = testValidator.isValid(
-                new CategoryTemplateApi("", "", "", ""), context);
+                new CategoryTemplateApi("", "", "", "", null), context);
         assertThat(valid, is(false));
     }
 
@@ -55,7 +55,7 @@ class NotBlankCategoryTemplateValidatorTest {
     void isValidWhenValuesNotBlank() {
 
         boolean valid = testValidator.isValid(
-                new CategoryTemplateApi("CC01", "Test01", "CC02", "CC01"), context);
+                new CategoryTemplateApi("CC01", "Test01", "CC02", "CC01", null), context);
         assertThat(valid, is(true));
     }
 

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/ResolutionsInfoControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/ResolutionsInfoControllerImplTest.java
@@ -65,7 +65,7 @@ class ResolutionsInfoControllerImplTest extends BaseControllerImplTest {
     @Test
     void postResolutionsInfo() {
         final CategoryTemplateApi resolutions = new CategoryTemplateApi("RESOLUTIONS",
-            "Resolutions", "RESOLUTIONS", null);
+            "Resolutions", "RESOLUTIONS", null, null);
         final FormTemplateApi formTemplateApi = new FormTemplateApi();
         final FormTemplateApi resolutionsForm = new FormTemplateApi(RESOLUTIONS_FORM);
 

--- a/src/test/java/uk/gov/companieshouse/efs/web/formtemplates/controller/FormTemplateControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/formtemplates/controller/FormTemplateControllerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.efs.web.categorytemplates.controller.CategoryTypeConstants.ROOT;
 
 import java.util.Arrays;
 import java.util.List;
@@ -48,14 +49,14 @@ class FormTemplateControllerTest extends BaseControllerImplTest {
      *     CAT1_SUB_LEVEL2   CAT2_SUB_LEVEL2
      */
     public static final CategoryTemplateApi INSOLVENCY = new CategoryTemplateApi("INS",
-            "Insolvency", "", null);
+            "Insolvency", "", null, null);
     public static final CategoryTemplateApi CAT1_SUB_LEVEL1 = new CategoryTemplateApi(
-            "CAT1_SUB_LEVEL1", "Dummy category 1, subcategory level 1", "CAT_TOP_LEVEL", null);
+            "CAT1_SUB_LEVEL1", "Dummy category 1, subcategory level 1", "CAT_TOP_LEVEL", null, null);
     public static final CategoryTemplateApi CAT2_SUB_LEVEL1 = new CategoryTemplateApi(
-            "CAT2_SUB_LEVEL1", "Dummy category 2, subcategory level 1", "CAT_TOP_LEVEL", null);
+            "CAT2_SUB_LEVEL1", "Dummy category 2, subcategory level 1", "CAT_TOP_LEVEL", null, null);
 
     public static final CategoryTemplateApi INS_SUB_LEVEL1 = new CategoryTemplateApi(
-            "INS_SUB_LEVEL1", "Dummy ins category 1, subcategory level 1", "INS", null);
+            "INS_SUB_LEVEL1", "Dummy ins category 1, subcategory level 1", "INS", null, null);
 
     public static final FormTemplateApi FORM_TEMPLATE_1 = new FormTemplateApi("CC01", "Test01", "CAT1_SUB_LEVEL1",
             "100", true, true, null);
@@ -111,6 +112,12 @@ class FormTemplateControllerTest extends BaseControllerImplTest {
         assertThat(result, is(ViewConstants.GONE.asView()));
     }
 
+    private void setupParentCategory() {
+        when(categoryTemplateAttribute.getParentCategory()).thenReturn(new CategoryTemplateApi());
+        when(categoryTemplateService.getCategoryTemplate(ROOT.getValue())).thenReturn(
+                new ApiResponse<>(200, getHeaders(), new CategoryTemplateApi()));
+    }
+
     @Test
     void formTemplateWhenSubmissionOpen() {
 
@@ -120,6 +127,7 @@ class FormTemplateControllerTest extends BaseControllerImplTest {
         submission.setPresenter(presenter);
 
         expectOpenSubmission(submission, CAT1_SUB_LEVEL1);
+        when(categoryTemplateAttribute.getParentCategory()).thenReturn(new CategoryTemplateApi());
 
         String template = testController.formTemplate(SUBMISSION_ID, COMPANY_NUMBER, CAT1_SUB_LEVEL1.getCategoryType(),
                 categoryTemplateAttribute, formTemplateAttribute, model, servletRequest);
@@ -149,6 +157,8 @@ class FormTemplateControllerTest extends BaseControllerImplTest {
 
         when(formTemplateAttribute.getFormType()).thenReturn(FORM_TEMPLATE_1.getFormType());
 
+        when(categoryTemplateAttribute.getParentCategory()).thenReturn(new CategoryTemplateApi());
+
         String template = testController.formTemplate(SUBMISSION_ID, COMPANY_NUMBER, CAT1_SUB_LEVEL1.getCategoryType(),
             categoryTemplateAttribute, formTemplateAttribute, model, servletRequest);
 
@@ -177,6 +187,8 @@ class FormTemplateControllerTest extends BaseControllerImplTest {
         when(formTemplateAttribute.getFormTemplateList()).thenReturn(FORM_TEMPLATE_LIST);
 
         when(formTemplateAttribute.getFormType()).thenReturn(FORM_TEMPLATE_1.getFormType());
+
+        when(categoryTemplateAttribute.getParentCategory()).thenReturn(new CategoryTemplateApi());
 
         String template = testController.formTemplate(SUBMISSION_ID, COMPANY_NUMBER, CAT2_SUB_LEVEL1.getCategoryType(),
             categoryTemplateAttribute, formTemplateAttribute, model, servletRequest);
@@ -250,6 +262,8 @@ class FormTemplateControllerTest extends BaseControllerImplTest {
         submission.setPresenter(presenter);
 
         expectOpenSubmission(submission, CAT1_SUB_LEVEL1);
+
+        when(categoryTemplateAttribute.getParentCategory()).thenReturn(new CategoryTemplateApi());
 
         String template = testController.formTemplate(SUBMISSION_ID, companyNumber, CAT1_SUB_LEVEL1.getCategoryType(),
                 categoryTemplateAttribute, formTemplateAttribute, model, servletRequest);


### PR DESCRIPTION
PR extends dynamic guidance to category and document selection screen. 

Uses new field in CategoryTemplateAPI to pass fragment IDs to the category and document selection screens. Thymeleaf then loads fragments with the path `fragments/categorySelection/guidance :: guidance' + fragmentID` where fragmentID is the ID passed from the Category template model. 
Multiple fragments can be passed with successive fragments being appended one after another. 
Due to the category template attribute not being populated for the root category a new method `getRootCategory` was needed and is called when the guidance fragment list is null. 

Guidance fragments in the API. In the category template collection there is a field "guidanceTexts" which is a list of integers which are the IDs of the fragments needed for that category.

API PR: https://github.com/companieshouse/efs-submission-api/pull/55

[BI-7097](https://companieshouse.atlassian.net/browse/BI-7097)