### PR TITLE
Added dynamic text to check details for SH19 service type

### DIFF
--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/CheckDetailsControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/CheckDetailsControllerImpl.java
@@ -129,7 +129,7 @@ public class CheckDetailsControllerImpl extends BaseControllerImpl implements Ch
         checkDetailsAttribute.setDocumentUploadedList(submission.getSubmissionForm().getFileDetails().getList());
         checkDetailsAttribute.setPaymentCharge(submission.getFeeOnSubmission());
         checkDetailsAttribute.setConfirmAuthorised(submission.getConfirmAuthorised());
-        checkDetailsAttribute.setFormType(submission.getSubmissionForm().getFormType());
+        checkDetailsAttribute.setFormType(documentType);
         model.addAttribute("showAuthStatement", topLevelCategory == INSOLVENCY);
         addTrackingAttributeToModel(model);
     }

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/CheckDetailsControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/CheckDetailsControllerImpl.java
@@ -131,7 +131,6 @@ public class CheckDetailsControllerImpl extends BaseControllerImpl implements Ch
         checkDetailsAttribute.setConfirmAuthorised(submission.getConfirmAuthorised());
         checkDetailsAttribute.setFormType(documentType);
         model.addAttribute("showAuthStatement", topLevelCategory == INSOLVENCY);
-        model.addAttribute("documentType", documentType);
         addTrackingAttributeToModel(model);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/CheckDetailsControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/CheckDetailsControllerImpl.java
@@ -129,6 +129,7 @@ public class CheckDetailsControllerImpl extends BaseControllerImpl implements Ch
         checkDetailsAttribute.setDocumentUploadedList(submission.getSubmissionForm().getFileDetails().getList());
         checkDetailsAttribute.setPaymentCharge(submission.getFeeOnSubmission());
         checkDetailsAttribute.setConfirmAuthorised(submission.getConfirmAuthorised());
+        checkDetailsAttribute.setFormType(submission.getSubmissionForm().getFormType());
         model.addAttribute("showAuthStatement", topLevelCategory == INSOLVENCY);
         addTrackingAttributeToModel(model);
     }

--- a/src/main/java/uk/gov/companieshouse/efs/web/model/CheckDetailsModel.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/model/CheckDetailsModel.java
@@ -19,6 +19,7 @@ public class CheckDetailsModel {
     private List<FileDetailApi> documentUploadedList;
     private String paymentCharge;
     private Boolean confirmAuthorised;
+    private String formType;
 
     public String getSubmissionId() {
         return submissionId;
@@ -76,6 +77,14 @@ public class CheckDetailsModel {
         this.confirmAuthorised = confirmAuthorised;
     }
 
+    public String getFormType() {
+        return formType;
+    }
+
+    public void setFormType(String formType) {
+        this.formType = formType;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -91,21 +100,27 @@ public class CheckDetailsModel {
             .equals(getDocumentTypeDescription(), that.getDocumentTypeDescription()) && Objects
             .equals(getDocumentUploadedList(), that.getDocumentUploadedList()) && Objects
             .equals(getPaymentCharge(), that.getPaymentCharge()) && Objects
-            .equals(getConfirmAuthorised(), that.getConfirmAuthorised());
+            .equals(getConfirmAuthorised(), that.getConfirmAuthorised()) && Objects
+                .equals(getFormType(), that.getFormType());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getSubmissionId(), getCompanyName(), getCompanyNumber(), getDocumentTypeDescription(),
-            getDocumentUploadedList(), getPaymentCharge(), getConfirmAuthorised());
+        return Objects.hash(getSubmissionId(), getCompanyName(), getCompanyNumber(),
+                getDocumentTypeDescription(), getDocumentUploadedList(), getPaymentCharge(),
+                getConfirmAuthorised(), getFormType());
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("submissionId", submissionId)
-            .append("companyName", companyName).append("companyNumber", companyNumber)
-            .append("documentTypeDescription", documentTypeDescription)
-            .append("documentUploadedList", documentUploadedList).append("paymentCharge", paymentCharge)
-            .append("confirmAuthorised", confirmAuthorised).toString();
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("submissionId", submissionId)
+                .append("companyName", companyName)
+                .append("companyNumber", companyNumber)
+                .append("documentTypeDescription", documentTypeDescription)
+                .append("documentUploadedList", documentUploadedList)
+                .append("paymentCharge", paymentCharge)
+                .append("confirmAuthorised", confirmAuthorised)
+                .append("formType", getFormType()).toString();
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -382,6 +382,8 @@ checkDetails.authorised.statement=I confirm I am authorised to send this documen
 checkDetails.button.submit=Submit document
 checkDetails.button.payAndSubmit=Pay for and submit document
 checkDetails.action.change=Change
+checkDetails.service.SH19=(Standard service)
+checkDetails.service.SH19_SAMEDAY=(Same day service)
 
 confirmation.title=Document uploaded successfully
 confirmation.banner.ref=Your reference number is

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -382,8 +382,8 @@ checkDetails.authorised.statement=I confirm I am authorised to send this documen
 checkDetails.button.submit=Submit document
 checkDetails.button.payAndSubmit=Pay for and submit document
 checkDetails.action.change=Change
-checkDetails.service.SH19=(Standard service)
-checkDetails.service.SH19_SAMEDAY=(Same day service)
+checkDetails.service.standard=(Standard service)
+checkDetails.service.same.day=(Same day service)
 
 confirmation.title=Document uploaded successfully
 confirmation.banner.ref=Your reference number is

--- a/src/main/resources/templates/checkDetails.html
+++ b/src/main/resources/templates/checkDetails.html
@@ -10,10 +10,10 @@
 <body class="govuk-template__body" layout:fragment="content">
 <div class="govuk-width-container">
     <form id="lookup-form" th:action="@{/efs-submission/{id}/company/{number}/check-your-details(id=*{submissionId},number=*{companyNumber})}" th:object="${checkDetails}" class="form" method="post">
-        <a class="govuk-back-link" th:if="${#strings.startsWith(documentType, 'SH19')}"
+        <a class="govuk-back-link" th:if="${#strings.startsWith(checkDetails.formType, 'SH19')}"
            th:href="@{/efs-submission/{id}/company/{companyNumber}/sh19-delivery(id=*{submissionId},companyNumber=*{companyNumber})}"
            th:text="#{link.back}"></a>
-        <a class="govuk-back-link" th:unless="${#strings.startsWith(documentType, 'SH19')}"
+        <a class="govuk-back-link" th:unless="${#strings.startsWith(checkDetails.formType, 'SH19')}"
            th:href="@{/efs-submission/{id}/company/{companyNumber}/document-upload(id=*{submissionId},companyNumber=*{companyNumber})}"
            th:text="#{link.back}"></a>
 

--- a/src/main/resources/templates/checkDetails.html
+++ b/src/main/resources/templates/checkDetails.html
@@ -65,9 +65,11 @@
                         <div th:if="${checkDetails.paymentCharge}" class="govuk-summary-list__row">
                             <dt th:text="#{checkDetails.payment.charge}" class="govuk-summary-list__key"></dt>
                             <dd class="govuk-summary-list__value"  id="paymentCharge">
-<!--                                Span elements get removed and just leaves the text-->
+<!--                                th:remove removes the span elements and leaves the text behind-->
                                 <span th:utext="*{'&pound;' + paymentCharge}" th:remove="tag"></span>
-                                <span th:if="${checkDetails.formType != null}" th:text="#{ checkDetails.service.__${checkDetails.formType}__ }" th:remove="tag"></span>
+
+                                <span th:if="${checkDetails.formType == 'SH19'}" th:text="#{checkDetails.service.standard}" th:remove="tag"></span>
+                                <span th:if="${checkDetails.formType == 'SH19_SAMEDAY'}" th:text="#{checkDetails.service.same.day}" th:remove="tag"></span>
                             </dd>
                         </div>
                     </dl>

--- a/src/main/resources/templates/checkDetails.html
+++ b/src/main/resources/templates/checkDetails.html
@@ -64,8 +64,10 @@
                         </div>
                         <div th:if="${checkDetails.paymentCharge}" class="govuk-summary-list__row">
                             <dt th:text="#{checkDetails.payment.charge}" class="govuk-summary-list__key"></dt>
-                            <dd class="govuk-summary-list__value"  id="paymentCharge"
-                                th:utext="*{'&pound;' + paymentCharge}">
+                            <dd class="govuk-summary-list__value"  id="paymentCharge">
+<!--                                Span elements get removed and just leaves the text-->
+                                <span th:utext="*{'&pound;' + paymentCharge}" th:remove="tag"></span>
+                                <span th:if="${checkDetails.formType != null}" th:text="#{ checkDetails.service.__${checkDetails.formType}__ }" th:remove="tag"></span>
                             </dd>
                         </div>
                     </dl>

--- a/src/test/java/uk/gov/companieshouse/efs/web/model/CheckDetailsModelTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/model/CheckDetailsModelTest.java
@@ -18,6 +18,7 @@ class CheckDetailsModelTest {
     private static final String SUBMISSION_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
     private static final String COMPANY_NAME = "TEST COMPANY LTD";
     private static final String COMPANY_NUMBER = "11111111";
+    public static final String EXAMPLE_FORM_TYPE = "FORM_TYPE";
 
     private CheckDetailsModel checkDetailsModel;
 
@@ -98,6 +99,15 @@ class CheckDetailsModelTest {
     }
 
     @Test
+    void getSetFormType() {
+        assertThat(checkDetailsModel.getFormType(), is(nullValue()));
+
+        checkDetailsModel.setFormType(EXAMPLE_FORM_TYPE);
+        assertThat(checkDetailsModel.getFormType(), is(EXAMPLE_FORM_TYPE));
+        assertThat(checkDetailsModel.getFormType(), sameInstance(EXAMPLE_FORM_TYPE));
+    }
+
+    @Test
     void equalsAndHashCode() {
         EqualsVerifier.forClass(CheckDetailsModel.class)
                 .usingGetClass().suppress(Warning.NONFINAL_FIELDS).verify();
@@ -107,9 +117,10 @@ class CheckDetailsModelTest {
     @Test
     void toStringTest() {
         final String stringFormat = "CheckDetailsModel[submissionId=%s,companyName=%s,companyNumber=%s," +
-                "documentTypeDescription=%s,documentUploadedList=%s,paymentCharge=%s,confirmAuthorised=%s]";
+                "documentTypeDescription=%s,documentUploadedList=%s,paymentCharge=%s,confirmAuthorised=%s,formType=%s]";
 
         assertThat(checkDetailsModel.toString(),
-                is(String.format(stringFormat, "<null>", "<null>", "<null>", "<null>", "<null>", "<null>", "<null>", "<null>")));
+                is(String.format(stringFormat, "<null>", "<null>", "<null>", "<null>", "<null>",
+                        "<null>", "<null>", "<null>", "<null>")));
     }
 }


### PR DESCRIPTION
Added dynamic text to the fee field indicating the service type (standard or same day).
Added form type to check details model
checkDetails template compares form type against SH19 and SH19_SAMEDAY
Fetches relevant message for the service type

Resolves: [BI-8066](https://companieshouse.atlassian.net/browse/BI-8066)