### PR TITLE
Updated version of log4j to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,10 @@
         <environment-reader-library.version>1.3.2</environment-reader-library.version>
         <common-web-java.version>1.5.0</common-web-java.version>
         <commons-fileupload.version>1.4</commons-fileupload.version>
-        <structured-logging.version>1.9.0</structured-logging.version>
+
+        <!-- Logging -->
+        <log4j-bom.version>2.16.0</log4j-bom.version>
+        <structured-logging.version>1.9.10</structured-logging.version>
 
         <thymeleaf-layout-dialect.version>2.3.0</thymeleaf-layout-dialect.version>
         <commons-lang3.version>3.10</commons-lang3.version>
@@ -65,6 +68,15 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Fix for CVE-2021-44228 -->
+            <!-- Required until v2.5.8 springframework & v2.6.2 springboot -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>${log4j-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
Fix for log4j security vulnerability

DEBT-1447

Have run service and logs displayed as expected

`➜  efs-submission-web mvn dependency:tree | grep log4j`
`[INFO] |  +- org.apache.logging.log4j:log4j-to-slf4j:jar:2.16.0:compile`
`[INFO] |  |  \- org.apache.logging.log4j:log4j-api:jar:2.16.0:compile`
`[INFO] |  +- org.apache.logging.log4j:log4j-core:jar:2.16.0:compile`