### PR TITLE
Update the error message on Remove Document screen

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -352,7 +352,7 @@ documentUpload.button.continue=Continue
 
 removeDocument.title=Remove the uploaded document
 removeDocument.page.title=Are you sure that you want to remove document \''{0}\''?
-removeDocument.error=You must tell us if you want to remove the document
+removeDocument.error=Select yes if you want to remove this document
 removeDocument.button.yes=Yes
 removeDocument.button.no=No
 removeDocument.button.continue=Continue


### PR DESCRIPTION
Following meeting with Content team, update the message displayed on the Remove Document screen

BI-11254

<img width="789" alt="Screenshot 2022-06-15 at 8 21 54 am" src="https://user-images.githubusercontent.com/2736331/173767938-0032ce56-c36a-48d2-bbbc-b7148156afef.png">