### PR TITLE
Update OWASP Dependency check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ build:
 dist: test-unit
 
 .PHONY: sonar
-sonar:
+sonar:	security-check
 	mvn sonar:sonar
 
 .PHONY: sonar-pr-analysis
@@ -59,5 +59,5 @@ sonar-pr-analysis:
 
 .PHONY: security-check
 security-check:
-	mvn compile org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=4 -DassemblyAnalyzerEnabled=false
+	mvn compile org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=11 -DassemblyAnalyzerEnabled=false
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
         <!-- Logging -->
         <log4j-bom.version>2.17.0</log4j-bom.version>
-        <structured-logging.version>1.9.14</structured-logging.version>
+        <structured-logging.version>1.9.12</structured-logging.version>
 
         <thymeleaf-layout-dialect.version>2.3.0</thymeleaf-layout-dialect.version>
         <commons-lang3.version>3.10</commons-lang3.version>
@@ -65,6 +65,10 @@
             ${project.basedir}/target/site/jacoco-it/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
         <sonar.jacoco.reports>${project.basedir}/target/site</sonar.jacoco.reports>
+        <sonar.dependencyCheck.htmlReportPath>
+            ${project.basedir}/target/dependency-check-report.html
+        </sonar.dependencyCheck.htmlReportPath>
+        <sonar.java.binaries>${project.basedir}/target</sonar.java.binaries>
         <!-- OWASP dependency-->
         <dependency-check-plugin.version>8.4.0</dependency-check-plugin.version>
     </properties>
@@ -336,6 +340,9 @@
                 <artifactId>dependency-check-maven</artifactId>
                 <version>${dependency-check-plugin.version}</version>
                 <configuration>
+                    <formats>
+                        <format>html</format>
+                    </formats>
                     <suppressionFiles>
                         <suppressionFile>suppress.xml</suppressionFile>
                     </suppressionFiles>


### PR DESCRIPTION
Makefile  - build to fail on CVSS=11 and add security-check to sonar.

POM - reverted structured logging version, add HTML formatting and path for dependency check report.

BI-13350