### PR TITLE
Update govuk-frontend version from 3.11.0 to 4.6.0

### DIFF
--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -9,7 +9,7 @@
         th:href="@{{cdnUrl}/stylesheets/js.css(cdnUrl=${@environment.getProperty('cdn.url')})}"
         media="all" rel="stylesheet" type="text/css" />
     <link
-        th:href="@{{cdnUrl}/stylesheets/govuk-frontend/v3.11.0/govuk-frontend-3.11.0.min.css(cdnUrl=${@environment.getProperty('cdn.url')})}"
+        th:href="@{{cdnUrl}/stylesheets/govuk-frontend/v4.6.0/govuk-frontend-4.6.0.min.css(cdnUrl=${@environment.getProperty('cdn.url')})}"
         media="all" rel="stylesheet" type="text/css" />
     <link
         th:href="@{{cdnUrl}/stylesheets/cookie-consent/cookie-banner-3.11.0.min.css(cdnUrl=${@environment.getProperty('cdn.url')})}"
@@ -32,8 +32,6 @@
 <body>
     <script th:src="@{{cdnUrl}/javascripts/app/body-js-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}"
             type="text/javascript"></script>
-    <script th:src="@{{cdnUrl}/javascripts/vendor/jquery-3.3.1.min.js(cdnUrl=${@environment.getProperty('cdn.url')})}"
-            type="text/javascript"></script>
 
     <div th:replace="fragments/piwikWithCookieCheck :: cookieBanner"></div>
 
@@ -52,7 +50,7 @@
             type="text/javascript"></script>
     <script th:src="@{{cdnUrl}/javascripts/vendor/application.js(cdnUrl=${@environment.getProperty('cdn.url')})}"
             type="text/javascript"></script>
-    <script th:src="@{{cdnUrl}/javascripts/govuk-frontend/v3.11.0/govuk-frontend-3.11.0.min.js(cdnUrl=${@environment.getProperty('cdn.url')})}"
+    <script th:src="@{{cdnUrl}/javascripts/govuk-frontend/v4.6.0/govuk-frontend-4.6.0.min.js(cdnUrl=${@environment.getProperty('cdn.url')})}"
             type="text/javascript"></script>
     <script type="text/javascript">window.GOVUKFrontend.initAll()</script>
     <script th:src="@{{cdnUrl}/javascripts/app/piwik-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}"


### PR DESCRIPTION
Update to the govuk-frontend stylesheet and javascript from 3.11.0 to the latest version 4.6.0 currently in CDN repo 
-  have also removed old `vendor/jquery-3.3.1` javascript, which I take to be not necessary
- left the `cookie-consent/cookie-banner-3.11.0` as is, since this is the latest version in [cdn](https://github.com/companieshouse/cdn.ch.gov.uk/tree/master/app/assets/stylesheets/cookie-consent)

BI-13354

Note re font families in `/assets/fonts/` or `/fonts/`
- I’ve spent time trying to figure out if we need to do a similar fix, as in officer-filing-web re the font families.
- see Readme note  [officer-filing-web: main](https://github.com/companieshouse/officer-filing-web/tree/main#readme), where they’ve included these styles [styles.html](https://github.com/companieshouse/officer-filing-web/blob/main/views/includes/styles.html) 
- in Docker I used the live CDN d6nh3dxv55e16.cloudfront.net and had to open a Chrome instance with web security disabled to prevent CORS being blocked by using open -na Google\ Chrome --args --user-data-dir=/tmp/temporary-chrome-profile-dir --disable-web-security
- however, GDS Transport font seemed to download and display ok.
- in the efs-web baseLayout [baseLayout.html](https://github.com/companieshouse/efs-submission-web/blob/master/src/main/resources/templates/layouts/baseLayout.html) I did add an equivalent override as in officer web, placed  at the end of the head element.
```
    <style th:inline="text">
        @font-face {
          font-family: "GDS Transport";
          src: url("[(@{{cdnUrl}/fonts/light-94a07e06a1-v2.woff2(cdnUrl=${@environment.getProperty('cdn.url')})})]") format("woff2"),
               url("[(@{{cdnUrl}/fonts/light-f591b13f7d-v2.woff(cdnUrl=${@environment.getProperty('cdn.url')})})]") format("woff");
          font-weight: normal;
          font-style: normal;
          font-display: fallback;
        }

        @font-face {
          font-family: "GDS Transport";
          src: url("[(@{{cdnUrl}/fonts/bold-b542beb274-v2.woff2(cdnUrl=${@environment.getProperty('cdn.url')})})]") format("woff2"),
               url("[(@{{cdnUrl}/fonts/bold-affa96571d-v2.woff(cdnUrl=${@environment.getProperty('cdn.url')})})]") format("woff");
          font-weight: bold;
          font-style: normal;
          font-display: fallback;
        }

        .govuk-footer__copyright-logo {
          background-image: url("[(@{{cdnUrl}/images/govuk-crest-2x.png(cdnUrl=${@environment.getProperty('cdn.url')})})]");
        }
    </style>
```
I’m thinking to not do any of this and let the change to 4.6.0 of the js and css go to tcats as it is.  If needed we can revisit the above again.