### PR TITLE
Add Service unavailable page for Planned Maintenance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
         <java.version>1.8</java.version>
         <java-session-handler.version>2.2.0</java-session-handler.version>
-        <private-api-sdk-java.version>2.0.159</private-api-sdk-java.version>
+        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
         <sdk-manager-java.version>1.5.10</sdk-manager-java.version>
         <rest-service-common-library.version>0.0.3</rest-service-common-library.version>
         <environment-reader-library.version>1.3.2</environment-reader-library.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
         <java.version>1.8</java.version>
         <java-session-handler.version>2.2.0</java-session-handler.version>
-        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.325</private-api-sdk-java.version>
         <sdk-manager-java.version>1.5.10</sdk-manager-java.version>
         <rest-service-common-library.version>0.0.3</rest-service-common-library.version>
         <environment-reader-library.version>1.3.2</environment-reader-library.version>

--- a/src/main/java/uk/gov/companieshouse/efs/web/EfsWebApplication.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/EfsWebApplication.java
@@ -19,6 +19,7 @@ public class EfsWebApplication implements WebMvcConfigurer {
     private final String guidancePageUrl;
     private final String insolvencyGuidancePageUrl;
     private final String accessibilityStatementPageUrl;
+    private final String serviceUnavailablePageUrl;
 
     /**
      * Constructor for EfsWebApplication.
@@ -31,13 +32,15 @@ public class EfsWebApplication implements WebMvcConfigurer {
         @Value("${start.page.url}") final String startPageUrl,
         @Value("${guidance.page.url}") final String guidancePageUrl,
         @Value("${insolvency.guidance.page.url}") final String insolvencyGuidancePageUrl,
-        @Value("${accessibility.statement.page.url}") final String accessibilityStatementPageUrl) {
+        @Value("${accessibility.statement.page.url}") final String accessibilityStatementPageUrl,
+        @Value("${service.unavailable.page.url}") final String serviceUnavailablePageUrl) {
         this.userDetailsInterceptor = userDetailsInterceptor;
         this.loggingInterceptor = loggingInterceptor;
         this.startPageUrl = startPageUrl;
         this.guidancePageUrl = guidancePageUrl;
         this.insolvencyGuidancePageUrl = insolvencyGuidancePageUrl;
         this.accessibilityStatementPageUrl = accessibilityStatementPageUrl;
+        this.serviceUnavailablePageUrl = serviceUnavailablePageUrl;
     }
 
     /**
@@ -51,7 +54,8 @@ public class EfsWebApplication implements WebMvcConfigurer {
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(loggingInterceptor);
         registry.addInterceptor(userDetailsInterceptor)
-                .excludePathPatterns(startPageUrl, guidancePageUrl, insolvencyGuidancePageUrl, accessibilityStatementPageUrl);
+                .excludePathPatterns(startPageUrl, guidancePageUrl, insolvencyGuidancePageUrl,
+                        accessibilityStatementPageUrl, serviceUnavailablePageUrl);
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/BaseControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/BaseControllerImpl.java
@@ -138,6 +138,10 @@ public abstract class BaseControllerImpl implements BaseController {
         this(logger, null, null, null, null);
     }
 
+    protected BaseControllerImpl(final Logger logger, final ApiClientService apiClientService) {
+        this(logger, null, apiClientService, null, null);
+    }
+
     protected BaseControllerImpl() {
     }
 

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/StaticPageController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/StaticPageController.java
@@ -23,7 +23,8 @@ public interface StaticPageController {
      * @return page to be displayed
      */
     @GetMapping("/start")
-    String start(@ModelAttribute CategoryTemplateModel categoryTemplateAttribute, Model model, ServletRequest servletRequest, SessionStatus sessionStatus);
+    String start(@ModelAttribute CategoryTemplateModel categoryTemplateAttribute, Model model,
+                 RedirectAttributes redirectAttributes, ServletRequest servletRequest, SessionStatus sessionStatus);
 
     /**
      * Directs user to the guidance page.

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/StaticPageController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/StaticPageController.java
@@ -56,6 +56,16 @@ public interface StaticPageController {
     String accessibilityStatement(Model model, ServletRequest request);
 
     /**
+     * Directs user to the service unavailable page.
+     *
+     * @param model   the service unavailable model
+     * @param request contains the chs session id
+     * @return page to be displayed
+     */
+    @GetMapping("/unavailable")
+    String serviceUnavailable(Model model, ServletRequest request);
+
+    /**
      * Directs user to company lookup service and sets the return URL to COMPANY_DETAIL view.
      */
     @GetMapping("{id}/companyLookup")

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImpl.java
@@ -14,6 +14,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import uk.gov.companieshouse.efs.web.categorytemplates.controller.CategoryTemplateControllerImpl;
 import uk.gov.companieshouse.efs.web.categorytemplates.model.CategoryTemplateModel;
+import uk.gov.companieshouse.efs.web.service.api.ApiClientService;
 import uk.gov.companieshouse.logging.Logger;
 
 /**
@@ -33,12 +34,14 @@ public class StaticPageControllerImpl extends BaseControllerImpl implements Stat
      * @param logger           the CH logger
      */
     @Autowired
-    public StaticPageControllerImpl(final Logger logger) {
-        super(logger);
+    public StaticPageControllerImpl(final Logger logger, final ApiClientService apiClientService) {
+        super(logger, apiClientService);
     }
 
     @Override
     public String start(@ModelAttribute CategoryTemplateModel categoryTemplateAttribute, Model model, ServletRequest servletRequest, SessionStatus sessionStatus) {
+
+
         sessionStatus.setComplete(); // invalidate the user's previous session if they have signed out
         model.addAttribute(TEMPLATE_NAME, ViewConstants.START.asView());
 
@@ -65,6 +68,14 @@ public class StaticPageControllerImpl extends BaseControllerImpl implements Stat
         model.addAttribute(TEMPLATE_NAME, ViewConstants.ACCESSIBILITY.asView());
 
         return ViewConstants.ACCESSIBILITY.asView();
+    }
+
+    @Override
+    public String serviceUnavailable(Model model, ServletRequest servletRequest) {
+
+        model.addAttribute(TEMPLATE_NAME, ViewConstants.UNAVAILABLE.asView());
+
+        return ViewConstants.UNAVAILABLE.asView();
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/ViewConstants.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/ViewConstants.java
@@ -31,7 +31,8 @@ public enum ViewConstants {
     CONFIRMATION("confirmation", "confirmation"),
     ERROR("error", "error"),
     MISSING("error/404", "error/404"),
-    GONE("/error/410", "error/410");
+    GONE("/error/410", "error/410"),
+    UNAVAILABLE("unavailable", "serviceUnavailable");
 
     private static final String SUBMISSION = "/efs-submission/";
     private static final String COMPANY = "company/{0}";

--- a/src/main/java/uk/gov/companieshouse/efs/web/security/WebApplicationSecurity.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/security/WebApplicationSecurity.java
@@ -131,8 +131,27 @@ public class WebApplicationSecurity {
         }
     }
 
+    /**
+     * static nested class for service unavailable page security.
+     */
     @Configuration
     @Order(6)
+    public static class ServiceUnavailablePageSecurityConfig extends WebSecurityConfigurerAdapter {
+        private String serviceUnavailablePageUrl;
+
+        public ServiceUnavailablePageSecurityConfig(
+                @Value("${service.unavailable.page.url}") final String serviceUnavailablePageUrl) {
+            this.serviceUnavailablePageUrl = serviceUnavailablePageUrl;
+        }
+
+        @Override
+        protected void configure(final HttpSecurity http) {
+            http.antMatcher(serviceUnavailablePageUrl);
+        }
+    }
+
+    @Configuration
+    @Order(7)
     public class CompanyAuthFilterSecurityConfig extends WebSecurityConfigurerAdapter {
 
         @Override
@@ -154,7 +173,7 @@ public class WebApplicationSecurity {
      * static nested class for resource level security.
      */
     @Configuration
-    @Order(7)
+    @Order(8)
     public class EfsWebResourceFilterConfig extends WebSecurityConfigurerAdapter {
 
         @Override

--- a/src/main/java/uk/gov/companieshouse/efs/web/service/api/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/service/api/ApiClientService.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.efs.web.service.api;
 
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.api.model.efs.healthcheck.HealthcheckApi;
 import uk.gov.companieshouse.api.model.efs.submissions.CompanyApi;
 import uk.gov.companieshouse.api.model.efs.submissions.ConfirmAuthorisedApi;
 import uk.gov.companieshouse.api.model.efs.submissions.FileListApi;
@@ -113,5 +114,12 @@ public interface ApiClientService {
      * @return the api response - true or false
      */
     ApiResponse<Boolean> isOnAllowList(final String emailAddress);
+
+    /**
+     * Get healthcheck.
+     *
+     * @return the model for the healthcheck json response
+     */
+    ApiResponse<HealthcheckApi> getHealthcheck();
 
 }

--- a/src/main/java/uk/gov/companieshouse/efs/web/service/api/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/service/api/ApiClientService.java
@@ -2,7 +2,7 @@ package uk.gov.companieshouse.efs.web.service.api;
 
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.model.ApiResponse;
-import uk.gov.companieshouse.api.model.efs.healthcheck.HealthcheckApi;
+import uk.gov.companieshouse.api.model.efs.maintenance.MaintenanceCheckApi;
 import uk.gov.companieshouse.api.model.efs.submissions.CompanyApi;
 import uk.gov.companieshouse.api.model.efs.submissions.ConfirmAuthorisedApi;
 import uk.gov.companieshouse.api.model.efs.submissions.FileListApi;
@@ -116,10 +116,10 @@ public interface ApiClientService {
     ApiResponse<Boolean> isOnAllowList(final String emailAddress);
 
     /**
-     * Get healthcheck.
+     * Get maintenance check.
      *
-     * @return the model for the healthcheck json response
+     * @return the model for the MaintenanceCheck json response
      */
-    ApiResponse<HealthcheckApi> getHealthcheck();
+    ApiResponse<MaintenanceCheckApi> getMaintenanceCheck();
 
 }

--- a/src/main/java/uk/gov/companieshouse/efs/web/service/api/impl/ApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/service/api/impl/ApiClientServiceImpl.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.efs.web.service.api.impl;
 
+import static uk.gov.companieshouse.efs.web.configuration.DataCacheConfig.IP_ALLOW_LIST;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,7 +11,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.model.ApiResponse;
-import uk.gov.companieshouse.api.model.efs.healthcheck.HealthcheckApi;
+import uk.gov.companieshouse.api.model.efs.maintenance.MaintenanceCheckApi;
 import uk.gov.companieshouse.api.model.efs.submissions.CompanyApi;
 import uk.gov.companieshouse.api.model.efs.submissions.ConfirmAuthorisedApi;
 import uk.gov.companieshouse.api.model.efs.submissions.FileListApi;
@@ -24,8 +26,6 @@ import uk.gov.companieshouse.efs.web.exception.UrlEncodingException;
 import uk.gov.companieshouse.efs.web.service.api.ApiClientService;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.sdk.manager.ApiClientManager;
-
-import static uk.gov.companieshouse.efs.web.configuration.DataCacheConfig.IP_ALLOW_LIST;
 
 /**
  * Service sends and receives secure REST messages to the api.
@@ -157,9 +157,10 @@ public class ApiClientServiceImpl extends BaseApiClientServiceImpl implements Ap
     }
 
     @Override
-    public ApiResponse<HealthcheckApi> getHealthcheck() {
-        final String uri = ROOT_URI + "/healthcheck";
+    public ApiResponse<MaintenanceCheckApi> getMaintenanceCheck() {
+        final String uri = ROOT_URI + "/maintenance";
 
-        return executeOp("getHealthcheck", uri, getApiClient().privateEfsResourceHandler().healthcheck().get(uri));
+        return executeOp("getMaintenance", uri,
+                getApiClient().privateEfsResourceHandler().maintenanceCheck().check().get(uri));
     }
 }

--- a/src/main/java/uk/gov/companieshouse/efs/web/service/api/impl/ApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/service/api/impl/ApiClientServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.api.model.efs.healthcheck.HealthcheckApi;
 import uk.gov.companieshouse.api.model.efs.submissions.CompanyApi;
 import uk.gov.companieshouse.api.model.efs.submissions.ConfirmAuthorisedApi;
 import uk.gov.companieshouse.api.model.efs.submissions.FileListApi;
@@ -153,5 +154,12 @@ public class ApiClientServiceImpl extends BaseApiClientServiceImpl implements Ap
 
         return executeOp("getIsOnAllowList", uri,
             getApiClient().privateEfsResourceHandler().companyAuthAllowList().isOnAllowList().get(uri));
+    }
+
+    @Override
+    public ApiResponse<HealthcheckApi> getHealthcheck() {
+        final String uri = ROOT_URI + "/healthcheck";
+
+        return executeOp("getHealthcheck", uri, getApiClient().privateEfsResourceHandler().healthcheck().get(uri));
     }
 }

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -18,6 +18,7 @@ piwik.url=https://matomo.platform.aws.chdev.org
 efs.piwik.start.goal.id=3
 policies.url=http://resources.companieshouse.gov.uk/serviceInformation.shtml
 start.page.url=/efs-submission/start
+service.unavailable.page.url=/efs-submission/unavailable
 web.signout.redirect.path=/efs-submission/start
 chs.signout.redirect.path=${chs.url}/efs-submission/start
 start.register.company=https://www.gov.uk/topic/company-registration-filing/starting-company

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,7 @@ piwik.url=${PIWIK_URL}
 efs.piwik.start.goal.id=${EFS_PIWIK_START_GOAL_ID}
 policies.url=${POLICIES_URL}
 start.page.url=${START_PAGE_URL}
+service.unavailable.page.url=${SERVICE_UNAVAILABLE_PAGE_URL}
 web.signout.redirect.path=${WEB_SIGNOUT_REDIRECT_PATH}
 chs.signout.redirect.path=${chs.url}${WEB_SIGNOUT_REDIRECT_PATH}
 start.register.company=${START_PAGE_REGISTER_COMPANY}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -57,7 +57,7 @@ start.different.services.list.item5=close a company
 
 # Service Unavailable page
 unavailable.title=Sorry this service is unavailable
-unavailable.description=You will be able to use the service from
+unavailable.description=You will be able to use the service from {0} 
 
 
 # Guidance page

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -55,6 +55,11 @@ start.different.services.list.item3=file a confirmation statement for a company
 start.different.services.list.item4=make changes to a company
 start.different.services.list.item5=close a company
 
+# Service Unavailable page
+unavailable.title=Sorry this service is unavailable
+unavailable.description=You will be able to use the service from
+
+
 # Guidance page
 guidance.title=Guidance - Upload a document to Companies House
 guidance.page.title=Upload a document to Companies House

--- a/src/main/resources/templates/serviceUnavailable.html
+++ b/src/main/resources/templates/serviceUnavailable.html
@@ -13,7 +13,7 @@
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds-from-desktop">
                     <h1 class="govuk-heading-xl" th:text="#{unavailable.title}"></h1>
-                    <p class="govuk-body-l" th:text="#{unavailable.description}">
+                    <p class="govuk-body-l" th:text="#{unavailable.description(*{date})}">
                         <span id="date" th:text="${date}"></span>
                     </p>
                 </div>

--- a/src/main/resources/templates/serviceUnavailable.html
+++ b/src/main/resources/templates/serviceUnavailable.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/baseLayout}"
+      lang="en">
+<head>
+    <title th:text="#{unavailable.title}"></title>
+</head>
+<body class="govuk-template__body js-enabled" layout:fragment="content">
+    <div class="govuk-width-container">
+        <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds-from-desktop">
+                    <h1 class="govuk-heading-xl" th:text="#{unavailable.title}"></h1>
+                    <p class="govuk-body-l" th:text="#{unavailable.description}">
+                        <span id="date" th:text="${date}"></span>
+                    </p>
+                </div>
+            </div>
+        </main>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/serviceUnavailable.html
+++ b/src/main/resources/templates/serviceUnavailable.html
@@ -13,9 +13,7 @@
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds-from-desktop">
                     <h1 class="govuk-heading-xl" th:text="#{unavailable.title}"></h1>
-                    <p class="govuk-body-l" th:text="#{unavailable.description(*{date})}">
-                        <span id="date" th:text="${date}"></span>
-                    </p>
+                    <p class="govuk-body-l" th:text="#{unavailable.description(${date})}"></p>
                 </div>
             </div>
         </main>

--- a/src/test/java/uk/gov/companieshouse/efs/web/EfsWebApplicationTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/EfsWebApplicationTest.java
@@ -35,7 +35,8 @@ class EfsWebApplicationTest {
             "/efs-submission/start",
             "/efs-submission/guidance",
             "/efs-submission/insolvency-guidance",
-            "/efs-submission/accessibility-statement"
+            "/efs-submission/accessibility-statement",
+            "/efs-submission/unavailable"
             );
     }
 
@@ -49,6 +50,7 @@ class EfsWebApplicationTest {
         verify(registry).addInterceptor(userDetailsInterceptor);
         verify(interceptorRegistration)
             .excludePathPatterns("/efs-submission/start", "/efs-submission/guidance",
-                "/efs-submission/insolvency-guidance", "/efs-submission/accessibility-statement");
+                "/efs-submission/insolvency-guidance", "/efs-submission/accessibility-statement",
+                "/efs-submission/unavailable");
     }
 }

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImplTest.java
@@ -28,7 +28,7 @@ class StaticPageControllerImplTest extends BaseControllerImplTest {
     @BeforeEach
     protected void setUp() {
         setUpHeaders();
-        testController = new StaticPageControllerImpl(logger);
+        testController = new StaticPageControllerImpl(logger, apiClientService);
         ((StaticPageControllerImpl) testController).setChsUrl(CHS_URL);
         ReflectionTestUtils.setField(testController, "registrationsEnabled", false);
     }

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImplTest.java
@@ -35,7 +35,8 @@ class StaticPageControllerImplTest extends BaseControllerImplTest {
 
     @Test
     void startPage() {
-        assertThat(testController.start(categoryTemplateAttribute, model, servletRequest, sessionStatus), is(ViewConstants.START.asView()));
+        assertThat(testController.start(categoryTemplateAttribute, model, attributes, servletRequest, sessionStatus),
+                is(ViewConstants.START.asView()));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/StaticPageControllerImplTest.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.efs.web.controller;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.api.model.efs.maintenance.MaintenanceCheckApi;
+import uk.gov.companieshouse.api.model.efs.maintenance.ServiceStatus;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -25,6 +29,11 @@ class StaticPageControllerImplTest extends BaseControllerImplTest {
     @Mock
     private RedirectAttributes attributes;
 
+    @Mock
+    private ApiResponse<MaintenanceCheckApi> maintenanceCheckApiApiResponse;
+    @Mock
+    private MaintenanceCheckApi maintenanceCheckApi;
+
     @BeforeEach
     protected void setUp() {
         setUpHeaders();
@@ -34,9 +43,27 @@ class StaticPageControllerImplTest extends BaseControllerImplTest {
     }
 
     @Test
-    void startPage() {
+    void startPageWhenApiServiceUp() {
+        when(apiClientService.getMaintenanceCheck()).thenReturn(maintenanceCheckApiApiResponse);
+        when(maintenanceCheckApiApiResponse.getData()).thenReturn(maintenanceCheckApi);
+        when(maintenanceCheckApi.getStatus()).thenReturn(ServiceStatus.UP);
         assertThat(testController.start(categoryTemplateAttribute, model, attributes, servletRequest, sessionStatus),
                 is(ViewConstants.START.asView()));
+    }
+
+    @Test
+    void startPageWhenApiServiceNotAvailable() {
+        when(apiClientService.getMaintenanceCheck()).thenReturn(maintenanceCheckApiApiResponse);
+        when(maintenanceCheckApiApiResponse.getData()).thenReturn(maintenanceCheckApi);
+        when(maintenanceCheckApi.getStatus()).thenReturn(ServiceStatus.OUT_OF_SERVICE);
+        when(maintenanceCheckApi.getMaintenanceEnd()).thenReturn("2023-11-14T17:04:00Z");
+        assertThat(testController.start(categoryTemplateAttribute, model, attributes, servletRequest, sessionStatus),
+                is(ViewConstants.UNAVAILABLE.asRedirectUri(CHS_URL)));
+    }
+
+    @Test
+    void unavailablePage() {
+        assertThat(testController.serviceUnavailable(model, servletRequest), is(ViewConstants.UNAVAILABLE.asView()));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/efs/web/security/WebApplicationSecurityTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/security/WebApplicationSecurityTest.java
@@ -88,6 +88,16 @@ class WebApplicationSecurityTest {
     }
 
     @Test
+    void serviceUnavailablePageConfig() {
+        final WebApplicationSecurity.ServiceUnavailablePageSecurityConfig testConfig =
+                new WebApplicationSecurity.ServiceUnavailablePageSecurityConfig("service unavailable page");
+
+        testConfig.configure(httpSecurity);
+
+        verify(httpSecurity).antMatcher("service unavailable page");
+    }
+
+    @Test
     void companyAuthFilterSecurityConfigTest() {
 
         final WebApplicationSecurity webApplicationSecurity = new WebApplicationSecurity(


### PR DESCRIPTION
- add call to EFS API on the `/start` page that check for Planned service maintenance
- add template for a Service Unavailable page which displays message and date / time

NOTE - I will have to change the sdk version in the pom, when the private-sdk is approved.

![Screenshot 2023-11-13 at 12 47 14 pm](https://github.com/companieshouse/efs-submission-web/assets/2736331/42636676-d13a-4282-bb5c-41e953d22044)

BI-13435

(chs-configs PR https://github.com/companieshouse/chs-configs/pull/2505
docker-chs-dev PR https://github.com/companieshouse/docker-chs-development/pull/862 )