### PR TITLE
Remove the out of date Covid-19 message from the confirmation screen

### DIFF
--- a/src/main/resources/templates/confirmation.html
+++ b/src/main/resources/templates/confirmation.html
@@ -41,13 +41,6 @@
                 <div class="govuk-body" th:unless="${registrarsPowers}">
                     <p th:text="#{confirmation.next.body3}"></p>
                 </div>
-                <div class="govuk-warning-text" th:unless="${isSH19SameDay}">
-                    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                    <strong class="govuk-warning-text__text govuk-!-margin-left-2 govuk-!-margin-top-4">
-                        <span class="govuk-warning-text__assistive">Warning</span>
-                        <span th:text="#{confirmation.happens.warning.text}"></span>
-                    </strong>
-                </div>
                 <h2 class="govuk-heading-m" th:text="#{confirmation.next.steps}"></h2>
                 <ul class="govuk-list">
                     <li>


### PR DESCRIPTION
NOTE - I've left the `confirmation.happens.warning.text` text in the `messages.prop` file, but maybe ought to remove from there too?

The message used to display above the 'What do you want to do next?" block:
<img width="516" alt="Screenshot 2023-11-17 at 1 44 47 pm" src="https://github.com/companieshouse/efs-submission-web/assets/2736331/cafeb40b-1fdb-4ea3-9d04-4650e8fc8379">

BI-13478