### PR TITLE
use parent-pom for dependency check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>1.3.1</version>
+        <version>2.1.4</version>
         <relativePath/>
     </parent>
     <artifactId>efs-submission-web</artifactId>
@@ -69,8 +69,6 @@
             ${project.basedir}/target/dependency-check-report.html
         </sonar.dependencyCheck.htmlReportPath>
         <sonar.java.binaries>${project.basedir}/target</sonar.java.binaries>
-        <!-- OWASP dependency-->
-        <dependency-check-plugin.version>8.4.0</dependency-check-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -392,26 +390,6 @@
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <version>3.1.1</version>
-            </plugin>
-            <plugin>
-                <groupId>org.owasp</groupId>
-                <artifactId>dependency-check-maven</artifactId>
-                <version>${dependency-check-plugin.version}</version>
-                <configuration>
-                    <formats>
-                        <format>html</format>
-                    </formats>
-                    <suppressionFiles>
-                        <suppressionFile>suppress.xml</suppressionFile>
-                    </suppressionFiles>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Uses parent-pom to resolve dependencies check version to allow applications to use api now data feeds is being switched off