### PR TITLE
fixing hc path for efs-submission-web

### DIFF
--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -9,7 +9,7 @@ locals {
   kms_alias                  = "alias/${var.aws_profile}/environment-services-kms"
   lb_listener_rule_priority  = 70
   lb_listener_paths          = ["/efs-submission*", "/efs-submission"]
-  healthcheck_path           = "/efs-submission-web/healthcheck" # healthcheck path for efs-submission-web
+  healthcheck_path           = "/efs-submission/healthcheck" # healthcheck path for efs-submission-web
   healthcheck_matcher        = "200"
   vpc_name                   = local.stack_secrets["vpc_name"]
   s3_config_bucket           = data.vault_generic_secret.shared_s3.data["config_bucket_name"]


### PR DESCRIPTION
incorrect hc was referenced in docker-chs-development, fixing hc path and hopefully this will fix the issue with the task in ecs recycling and failing. 