### PR TITLE
efs-submission-web tf changes

### DIFF
--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -19,7 +19,7 @@ terraform {
 }
 
 module "secrets" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.253"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.292"
 
   name_prefix = "${local.service_name}-${var.environment}"
   environment = var.environment
@@ -28,7 +28,8 @@ module "secrets" {
 }
 
 module "ecs-service" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.253"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.292"
+  read_only_root_filesystem = false
 
   # Environmental configuration
   environment             = var.environment


### PR DESCRIPTION
From investigating issue with deploying this service to aws with a healthy task we found that a new feature added to terraform-modules was impacting. I am changing our service tf code to have a newer version of that repo again but also adding a flag in to disable that read-only filesystem change as it is not allowing the service to be healthy as guided by Harish.
Relating to: https://github.com/companieshouse/terraform-modules/pull/306

