### PR TITLE
increasing memory value in live

### DIFF
--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
@@ -7,4 +7,4 @@ min_task_count = 2
 
 
 required_cpus = 512
-required_memory = 1024
+required_memory = 2048


### PR DESCRIPTION
[https://companieshouse.atlassian.net/browse/JU-1307](url)
As part of tech debt for this service we have checked the memory usage in Live AWS which often reaches above 60% and therefore we are increasing the memory value.