### PR TITLE
ASM-520 Hotfix for CoC Resolution error

### DIFF
--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/ResolutionsInfoController.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/ResolutionsInfoController.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.efs.web.controller;
 
-import static uk.gov.companieshouse.efs.web.controller.CompanyDetailControllerImpl.ATTRIBUTE_NAME;
-
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
@@ -12,12 +10,10 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.SessionAttributes;
-import uk.gov.companieshouse.efs.web.categorytemplates.controller.CategoryTemplateControllerImpl;
-import uk.gov.companieshouse.efs.web.categorytemplates.model.CategoryTemplateModel;
+import uk.gov.companieshouse.efs.web.formtemplates.controller.FormTemplateControllerImpl;
+import uk.gov.companieshouse.efs.web.formtemplates.model.FormTemplateModel;
 
 @RequestMapping(BaseControllerImpl.SERVICE_URI)
-@SessionAttributes(ATTRIBUTE_NAME)
 @SuppressWarnings("squid:S3753")
 /* S3753: "@Controller" classes that use "@SessionAttributes" must call "setComplete" on their "SessionStatus" objects
  *
@@ -27,19 +23,19 @@ import uk.gov.companieshouse.efs.web.categorytemplates.model.CategoryTemplateMod
 public interface ResolutionsInfoController {
 
     /**
-     * Get request for the category template.
+     * Get request for the resolutions info page.
      *
-     * @param categoryTemplateAttribute the category template details see {@link CategoryTemplateModel}
-     * @param model                     the category model
+     * @param formTemplateAttribute the form template details see {@link FormTemplateModel}
+     * @param model                     the MVC model
      * @param servletRequest            contains the chs session id
      * @return the view name
      */
     @GetMapping(value = {"{id}/company/{companyNumber}/resolutions-info"})
     String resolutionsInfo(@PathVariable String id, @PathVariable String companyNumber,
-                               @ModelAttribute(CategoryTemplateControllerImpl.ATTRIBUTE_NAME) CategoryTemplateModel categoryTemplateAttribute, Model model, HttpServletRequest servletRequest);
+                           @ModelAttribute(FormTemplateControllerImpl.ATTRIBUTE_NAME) FormTemplateModel formTemplateAttribute, Model model, HttpServletRequest servletRequest);
 
     @PostMapping(value = {"{id}/company/{companyNumber}/resolutions-info"}, params = {"action=submit"})
     String postResolutionsInfo(@PathVariable String id, @PathVariable String companyNumber,
-                                   @ModelAttribute(CategoryTemplateControllerImpl.ATTRIBUTE_NAME) CategoryTemplateModel categoryTemplateAttribute,
+                                   @ModelAttribute(FormTemplateControllerImpl.ATTRIBUTE_NAME) FormTemplateModel formTemplateAttribute,
                                    BindingResult binding, Model model, ServletRequest servletRequest, final HttpSession session);
 }

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/ResolutionsInfoControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/ResolutionsInfoControllerImpl.java
@@ -67,7 +67,7 @@ public class ResolutionsInfoControllerImpl extends BaseControllerImpl implements
 
     @Override
     public String postResolutionsInfo(@PathVariable String id, @PathVariable String companyNumber,
-        FormTemplateModel categoryTemplateAttribute, BindingResult binding, Model model, ServletRequest servletRequest, HttpSession session) {
+        FormTemplateModel formTemplateModel, BindingResult binding, Model model, ServletRequest servletRequest, HttpSession session) {
 
         return ViewConstants.DOCUMENT_UPLOAD.asRedirectUri(chsUrl, id, companyNumber);
     }

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/ResolutionsInfoControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/ResolutionsInfoControllerImpl.java
@@ -8,15 +8,19 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.SessionAttributes;
 import uk.gov.companieshouse.api.model.efs.submissions.SubmissionApi;
-import uk.gov.companieshouse.efs.web.categorytemplates.model.CategoryTemplateModel;
 import uk.gov.companieshouse.efs.web.categorytemplates.service.api.CategoryTemplateService;
+import uk.gov.companieshouse.efs.web.formtemplates.model.FormTemplateModel;
 import uk.gov.companieshouse.efs.web.formtemplates.service.api.FormTemplateService;
 import uk.gov.companieshouse.efs.web.service.api.ApiClientService;
 import uk.gov.companieshouse.efs.web.service.session.SessionService;
 import uk.gov.companieshouse.logging.Logger;
 
+import static uk.gov.companieshouse.efs.web.controller.CompanyDetailControllerImpl.ATTRIBUTE_NAME;
+
 @Controller
+@SessionAttributes(ATTRIBUTE_NAME)
 public class ResolutionsInfoControllerImpl extends BaseControllerImpl implements ResolutionsInfoController {
 
 
@@ -37,11 +41,14 @@ public class ResolutionsInfoControllerImpl extends BaseControllerImpl implements
     }
 
     @Override
-    public String resolutionsInfo(@PathVariable String id, @PathVariable String companyNumber,
-        CategoryTemplateModel categoryTemplateAttribute, Model model, HttpServletRequest servletRequest) {
+    public String resolutionsInfo(@PathVariable String id, @PathVariable String companyNumber, FormTemplateModel formTemplateAttribute, Model model, HttpServletRequest servletRequest) {
 
         final SubmissionApi submissionApi = Objects.requireNonNull(getSubmission(id));
-        categoryTemplateAttribute.setSubmissionId(submissionApi.getId());
+        formTemplateAttribute.setSubmissionId(submissionApi.getId());
+
+        if (submissionApi.getCompany() != null) {
+            formTemplateAttribute.setCompanyNumber(submissionApi.getCompany().getCompanyNumber());
+        }
 
         if (!ALLOWED_STATUSES.contains(submissionApi.getStatus())) {
             return ViewConstants.GONE.asView();
@@ -54,7 +61,7 @@ public class ResolutionsInfoControllerImpl extends BaseControllerImpl implements
 
     @Override
     public String postResolutionsInfo(@PathVariable String id, @PathVariable String companyNumber,
-        CategoryTemplateModel categoryTemplateAttribute, BindingResult binding, Model model, ServletRequest servletRequest, HttpSession session) {
+        FormTemplateModel categoryTemplateAttribute, BindingResult binding, Model model, ServletRequest servletRequest, HttpSession session) {
 
         return ViewConstants.DOCUMENT_UPLOAD.asRedirectUri(chsUrl, id, companyNumber);
     }

--- a/src/main/java/uk/gov/companieshouse/efs/web/controller/ResolutionsInfoControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/efs/web/controller/ResolutionsInfoControllerImpl.java
@@ -21,6 +21,12 @@ import static uk.gov.companieshouse.efs.web.controller.CompanyDetailControllerIm
 
 @Controller
 @SessionAttributes(ATTRIBUTE_NAME)
+@SuppressWarnings("squid:S3753")
+/* S3753: "@Controller" classes that use "@SessionAttributes" must call "setComplete" on their "SessionStatus" objects
+ *
+ * The nature of the web journey across several controllers means it's not appropriate to do this. However,
+ * setComplete() is properly called in ConfirmationControllerImpl at the end of the submission journey.
+ */
 public class ResolutionsInfoControllerImpl extends BaseControllerImpl implements ResolutionsInfoController {
 
 

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/BaseControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/BaseControllerImplTest.java
@@ -36,7 +36,6 @@ import uk.gov.companieshouse.session.handler.SessionHandler;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import java.text.MessageFormat;
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -63,14 +62,10 @@ public abstract class BaseControllerImplTest {
     protected static final String CHS_URL = "http://web.chs-dev:4000";
     protected static final String SUBMISSION_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
     protected static final String FILE_ID = "1234567890";
-    protected static final String CONFIRMATION_REF = "m6mo orcu mwgs c5pw";
     protected static final String COMPANY_NUMBER = "11111111";
     protected static final String COMPANY_NAME = "TEST COMPANY LTD";
     protected static final String USER_EMAIL = "tester@email.com";
     protected static final String SESSION_ID = "sess12345678";
-    protected static final Instant FIXED_NOW = Instant.parse("2020-03-15T09:44:08.108Z");
-    protected static final String NOT_FOUND_PAGE = ViewConstants.MISSING.asView();
-    protected static final String SERVICE_PROBLEM_PAGE = ViewConstants.ERROR.asView();
     protected static final String TEMPLATE_NAME = "templateName";
     protected static final String ORIGINAL_SUBMISSION_ID = "originalSubmissionId";
 
@@ -136,9 +131,9 @@ public abstract class BaseControllerImplTest {
     }
 
     protected void stubGetChsSession() {
-        Session session = new SessionImpl();
-        session.setCookieId(chsSessionId);
-        when(servletRequest.getAttribute(SessionHandler.CHS_SESSION_REQUEST_ATT_KEY)).thenReturn(session);
+        Session chsSession = new SessionImpl();
+        chsSession.setCookieId(chsSessionId);
+        when(servletRequest.getAttribute(SessionHandler.CHS_SESSION_REQUEST_ATT_KEY)).thenReturn(chsSession);
     }
 
     protected String getUrlWithId(final String template, final String id) {
@@ -159,18 +154,26 @@ public abstract class BaseControllerImplTest {
     }
 
     protected SubmissionApi createSubmission(final SubmissionStatus submitted) {
-        final SubmissionApi submission = new SubmissionApi();
 
-        submission.setId(SUBMISSION_ID);
-        submission.setStatus(submitted);
+        SubmissionApi submissionApi = new SubmissionApi();
 
-        submission.setPresenter(new PresenterApi("demo@ch"));
+        submissionApi.setId(SUBMISSION_ID);
+        submissionApi.setStatus(submitted);
+
+        submissionApi.setPresenter(new PresenterApi("demo@ch"));
 
         CompanyApi company = new CompanyApi();
         company.setCompanyNumber(COMPANY_NAME);
         company.setCompanyName(COMPANY_NUMBER);
 
-        submission.setCompany(company);
+        submissionApi.setCompany(company);
+
+        return submissionApi;
+    }
+
+    protected SubmissionApi createSubmissionNullCompany() {
+        submission.setId(SUBMISSION_ID);
+        submission.setPresenter(new PresenterApi("demo@ch"));
 
         return submission;
     }
@@ -298,11 +301,11 @@ public abstract class BaseControllerImplTest {
 
     @Test
     void testGetChsSessionId() {
-        Session session = mock(Session.class);
+        Session chsSession = mock(Session.class);
         when(request.getAttribute(SessionHandler.CHS_SESSION_REQUEST_ATT_KEY))
-                .thenReturn(session);
+                .thenReturn(chsSession);
         baseController.getChsSessionId(request);
-        verify(session).getCookieId();
+        verify(chsSession).getCookieId();
 
         when(request.getAttribute(SessionHandler.CHS_SESSION_REQUEST_ATT_KEY))
                 .thenReturn(null);
@@ -314,15 +317,15 @@ public abstract class BaseControllerImplTest {
         String fieldName = "testAnyErrorsFromResponse";
         String location = String.format("a.b.%s", fieldName);
 
-        BindingResult bindingResult = mock(BindingResult.class);
+        BindingResult mockResult = mock(BindingResult.class);
         ApiError apiError = mock(ApiError.class);
 
         when(apiResponse.getErrors()).thenReturn(Collections.singletonList(apiError));
         when(apiError.getLocation()).thenReturn(location);
         when(apiError.getErrorValues()).thenReturn(null);
 
-        baseController.addAnyErrorsFromResponse(bindingResult, apiResponse, x -> true);
+        baseController.addAnyErrorsFromResponse(mockResult, apiResponse, x -> true);
 
-        verify(bindingResult).rejectValue(eq(fieldName), isNull(), isNull(), anyString());
+        verify(mockResult).rejectValue(eq(fieldName), isNull(), isNull(), anyString());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/efs/web/controller/ResolutionsInfoControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/efs/web/controller/ResolutionsInfoControllerImplTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.companieshouse.api.model.efs.categorytemplates.CategoryTemplateApi;
 import uk.gov.companieshouse.api.model.efs.formtemplates.FormTemplateApi;
 import uk.gov.companieshouse.api.model.efs.submissions.SubmissionApi;
 import uk.gov.companieshouse.api.model.efs.submissions.SubmissionStatus;
@@ -23,7 +22,7 @@ class ResolutionsInfoControllerImplTest extends BaseControllerImplTest {
     private ResolutionsInfoController testController;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         setUpHeaders();
         testController = new ResolutionsInfoControllerImpl(logger, sessionService, apiClientService,
             formTemplateService, categoryTemplateService);
@@ -43,8 +42,8 @@ class ResolutionsInfoControllerImplTest extends BaseControllerImplTest {
         when(apiClientService.getSubmission(SUBMISSION_ID)).thenReturn(
             getSubmissionOkResponse(submission));
 
-        final String result = testController.resolutionsInfo(SUBMISSION_ID, COMPANY_NUMBER, categoryTemplateAttribute,
-            model, servletRequest);
+        final String result = testController.resolutionsInfo(SUBMISSION_ID, COMPANY_NUMBER, formTemplateAttribute,
+                model, servletRequest);
 
         assertThat(result, is(ViewConstants.RESOLUTIONS_INFO.asView()));
     }
@@ -56,23 +55,35 @@ class ResolutionsInfoControllerImplTest extends BaseControllerImplTest {
         when(apiClientService.getSubmission(SUBMISSION_ID)).thenReturn(
             getSubmissionOkResponse(submission));
 
-        final String result = testController.resolutionsInfo(SUBMISSION_ID, COMPANY_NUMBER, categoryTemplateAttribute,
-            model, servletRequest);
+        final String result = testController.resolutionsInfo(SUBMISSION_ID, COMPANY_NUMBER, formTemplateAttribute,
+                model, servletRequest);
+
+        assertThat(result, is(ViewConstants.GONE.asView()));
+    }
+
+    @Test
+    void getResolutionsInfoWhenSubmissionApiCompanyIsNull() {
+        final SubmissionApi submission = createSubmissionNullCompany();
+
+        when(apiClientService.getSubmission(SUBMISSION_ID)).thenReturn(
+                getSubmissionOkResponse(submission));
+        when(submission.getCompany()).thenReturn(null);
+
+        final String result = testController.resolutionsInfo(SUBMISSION_ID, COMPANY_NUMBER, formTemplateAttribute,
+                model, servletRequest);
 
         assertThat(result, is(ViewConstants.GONE.asView()));
     }
 
     @Test
     void postResolutionsInfo() {
-        final CategoryTemplateApi resolutions = new CategoryTemplateApi("RESOLUTIONS",
-            "Resolutions", "RESOLUTIONS", null, null);
         final FormTemplateApi formTemplateApi = new FormTemplateApi();
         final FormTemplateApi resolutionsForm = new FormTemplateApi(RESOLUTIONS_FORM);
 
         formTemplateApi.setFormType("RESOLUTIONS");
 
-        final String result = testController.postResolutionsInfo(SUBMISSION_ID, COMPANY_NUMBER, categoryTemplateAttribute,
-            bindingResult, model, servletRequest, session);
+        final String result = testController.postResolutionsInfo(SUBMISSION_ID, COMPANY_NUMBER, formTemplateAttribute,
+                bindingResult, model, servletRequest, session);
 
         assertThat(formTemplateApi.getFormType(), is(resolutionsForm.getFormType()));
         assertThat(result, is(ViewConstants.DOCUMENT_UPLOAD.asRedirectUri(CHS_URL, SUBMISSION_ID, COMPANY_NUMBER)));


### PR DESCRIPTION
Updates to attempt prevention of the `cidev` error when selecting "**Change of constitution**"  followed by "**Resolution**", resulting in the service not available page displayed:
1. Replaced `categoryTemplateAttributexxx` occurrences with `formTemplateAttribute` to match across the controller and `html` page for resolutions Info. 
2. Cleared down some SonarQube warnings

**SonarQube Notes**
In `BaseControllerImplTest` the errors list is used in `setUpApiResponse`

In `ResolutionsInfoControllerImpl`

1. Bind method parameters are configured the same way in all controllers
2. Call to `setComplete` not possible for this controller as it stands - see comment in the interface `ResolutionsInfoController`